### PR TITLE
fix: correct _default_value_for_type for temporal and unsupported types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "docs/index.md"
 authors = [
   {name = "Ivan Ogasawara", email = "ivan.ogasawara@gmail.com"}
 ]
-license = "Apache Software License 2.0"
+license = "Apache-2.0"
 requires-python = ">=3.10,<4"
 dependencies = [
   "pyyaml >=4",

--- a/src/arx/parser.py
+++ b/src/arx/parser.py
@@ -682,8 +682,21 @@ class Parser:
             return astx.LiteralString("")
         if isinstance(data_type, astx.NoneType):
             return astx.LiteralNone()
-        return astx.LiteralInt32(0)
+        if isinstance(data_type, astx.DateTime):
+            return astx.LiteralDateTime("1970-01-01T00:00:00")
+        if isinstance(data_type, astx.Timestamp):
+            return astx.LiteralTimestamp("1970-01-01T00:00:00")
+        if isinstance(data_type, astx.Date):
+            return astx.LiteralDate("1970-01-01")
+        if isinstance(data_type, astx.Time):
+            return astx.LiteralTime("00:00:00")
 
+        raise ParserException(
+            f"Parser: No default value defined for type "
+            f"'{type(data_type).__name__}'. "
+            f"An explicit initializer is required."
+        )
+    
     def parse_type(self) -> astx.DataType:
         """
         title: Parse a type annotation.

--- a/src/arx/parser.py
+++ b/src/arx/parser.py
@@ -696,7 +696,7 @@ class Parser:
             f"'{type(data_type).__name__}'. "
             f"An explicit initializer is required."
         )
-    
+
     def parse_type(self) -> astx.DataType:
         """
         title: Parse a type annotation.

--- a/tests/test_parser_branches.py
+++ b/tests/test_parser_branches.py
@@ -205,24 +205,21 @@ def test_parse_type_list_and_default_values() -> None:
         astx.LiteralNone,
     )
     assert isinstance(
-        parser._default_value_for_type(astx.DateTime()),
-        astx.LiteralDateTime
+        parser._default_value_for_type(astx.DateTime()), astx.LiteralDateTime
     )
     assert isinstance(
-        parser._default_value_for_type(astx.Timestamp()),
-        astx.LiteralTimestamp
+        parser._default_value_for_type(astx.Timestamp()), astx.LiteralTimestamp
     )
     assert isinstance(
-        parser._default_value_for_type(astx.Date()),
-        astx.LiteralDate
+        parser._default_value_for_type(astx.Date()), astx.LiteralDate
     )
     assert isinstance(
-        parser._default_value_for_type(astx.Time()), 
-        astx.LiteralTime
+        parser._default_value_for_type(astx.Time()), astx.LiteralTime
     )
 
     with pytest.raises(ParserException):
         parser._default_value_for_type(astx.ListType([astx.Int32()]))
+
 
 def test_parse_unary_and_prototype_error_paths() -> None:
     """

--- a/tests/test_parser_branches.py
+++ b/tests/test_parser_branches.py
@@ -206,9 +206,23 @@ def test_parse_type_list_and_default_values() -> None:
     )
     assert isinstance(
         parser._default_value_for_type(astx.DateTime()),
-        astx.LiteralInt32,
+        astx.LiteralDateTime
+    )
+    assert isinstance(
+        parser._default_value_for_type(astx.Timestamp()),
+        astx.LiteralTimestamp
+    )
+    assert isinstance(
+        parser._default_value_for_type(astx.Date()),
+        astx.LiteralDate
+    )
+    assert isinstance(
+        parser._default_value_for_type(astx.Time()), 
+        astx.LiteralTime
     )
 
+    with pytest.raises(ParserException):
+        parser._default_value_for_type(astx.ListType([astx.Int32()]))
 
 def test_parse_unary_and_prototype_error_paths() -> None:
     """


### PR DESCRIPTION
## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->

`_default_value_for_type` silently returned `LiteralInt32(0)` for any unrecognised type, including fully-supported temporal types like `DateTime`, `Timestamp`, `Date`, and `Time`. This produced incorrect AST nodes with no indication of the problem.
<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #004
-->

## How to test these changes
Updated `test_parse_type_list_and_default_values` to assert correct literal types are returned for all temporal types, and added a `pytest.raises(ParserException)` assertion for `ListType`.

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [x] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
