### PR TITLE
fix: return EOF token instead of raising IndexError in TokenList.get_token

### DIFF
--- a/src/arx/lexer.py
+++ b/src/arx/lexer.py
@@ -252,6 +252,13 @@ class TokenList:
           type: Token
           description: The next token from standard input.
         """
+        if self.position >= len(self.tokens):
+            last_loc = (
+                self.tokens[-1].location
+                if self.tokens
+                else SourceLocation(0, 0)
+            )
+            return Token(kind=TokenKind.eof, value="", location=last_loc)
         tok = self.tokens[self.position]
         self.position += 1
         return tok


### PR DESCRIPTION
## Pull Request description

<!-- Describe the purpose of your PR and the changes you have made. -->
TokenList.get_token() directly indexes self.tokens[self.position] without a bounds check. Calling get_next_token() past the end of the token list raises an unhandled IndexError with no source location, making it hard to debug and leaving the parser with no clean recovery path.

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #004
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [ ] new feature
- [ ] maintenance

About this PR:

- [ ] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
