### PR TITLE
feat(pyarx): add error and diagnostic layer

### DIFF
--- a/packages/pyarx/src/pyarx/__init__.py
+++ b/packages/pyarx/src/pyarx/__init__.py
@@ -4,6 +4,9 @@ title: Top-level package for PyArx.
 
 from importlib import metadata as importlib_metadata
 
+from pyarx.diagnostics import Diagnostic, DiagnosticSeverity
+from pyarx.errors import ArxError, CompileError, ParseError, RuntimeError
+
 _DISTRIBUTION_NAME = "pyarx"
 
 
@@ -23,4 +26,13 @@ __author__: str = "Ivan Ogasawara"
 __email__: str = "ivan.ogasawara@gmail.com"
 __version__: str = get_version()
 
-__all__ = ["__version__", "get_version"]
+__all__ = [
+    "ArxError",
+    "CompileError",
+    "Diagnostic",
+    "DiagnosticSeverity",
+    "ParseError",
+    "RuntimeError",
+    "__version__",
+    "get_version",
+]

--- a/packages/pyarx/src/pyarx/__init__.py
+++ b/packages/pyarx/src/pyarx/__init__.py
@@ -5,7 +5,12 @@ title: Top-level package for PyArx.
 from importlib import metadata as importlib_metadata
 
 from pyarx.diagnostics import Diagnostic, DiagnosticSeverity
-from pyarx.errors import ArxError, CompileError, ParseError, RuntimeError
+from pyarx.errors import (
+    ArxError,
+    CompileError,
+    ExecutionError,
+    ParseError,
+)
 
 _DISTRIBUTION_NAME = "pyarx"
 
@@ -31,8 +36,8 @@ __all__ = [
     "CompileError",
     "Diagnostic",
     "DiagnosticSeverity",
+    "ExecutionError",
     "ParseError",
-    "RuntimeError",
     "__version__",
     "get_version",
 ]

--- a/packages/pyarx/src/pyarx/diagnostics.py
+++ b/packages/pyarx/src/pyarx/diagnostics.py
@@ -1,0 +1,183 @@
+"""
+title: Structured diagnostic records for the PyArx public API.
+summary: >-
+  Define the stable, frozen Diagnostic record and the DiagnosticSeverity enum
+  that PyArx exposes to callers, plus the duck-typed helpers that translate
+  upstream irx structured diagnostics and arx parser exceptions into it. The
+  Diagnostic type strips the astx.AST node reference that irx records carry, so
+  external callers never see raw compiler internals. These modules never import
+  arx or irx at module load time, so importing pyarx.diagnostics stays free of
+  the LLVM toolchain.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DiagnosticSeverity(Enum):
+    """
+    title: Severity level of a diagnostic.
+    """
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+    HINT = "hint"
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """
+    title: One structured diagnostic exposed by the PyArx API.
+    attributes:
+      severity:
+        type: DiagnosticSeverity
+        description: The severity level of the diagnostic.
+      message:
+        type: str
+        description: The human-readable diagnostic message.
+      filename:
+        type: str
+        description: Source attribution, or "<string>" / "<unknown>".
+      line:
+        type: int | None
+        description: One-based source line, when known.
+      column:
+        type: int | None
+        description: One-based source column, when known.
+      code:
+        type: str | None
+        description: Stable diagnostic code, e.g. "S001", when known.
+    """
+
+    severity: DiagnosticSeverity
+    message: str
+    filename: str
+    line: int | None
+    column: int | None
+    code: str | None = None
+
+
+def _coerce_severity(value: object) -> DiagnosticSeverity:
+    """
+    title: Coerce an upstream severity value into a DiagnosticSeverity.
+    summary: >-
+      Current irx diagnostics expose severity as a plain string such as
+      "error"; enum-like values exposing `.value` are also handled.
+      Unrecognised values fall back to ERROR.
+    parameters:
+      value:
+        type: object
+    returns:
+      type: DiagnosticSeverity
+    """
+    if isinstance(value, DiagnosticSeverity):
+        return value
+    raw = getattr(value, "value", value)
+    try:
+        return DiagnosticSeverity(str(raw))
+    except ValueError:
+        return DiagnosticSeverity.ERROR
+
+
+def _resolve_source(record: object) -> object | None:
+    """
+    title: Return the best-effort source location of an irx diagnostic.
+    parameters:
+      record:
+        type: object
+    returns:
+      type: object | None
+    """
+    resolver = getattr(record, "resolved_source", None)
+    if callable(resolver):
+        resolved: object = resolver()
+        return resolved
+    source: object = getattr(record, "source", None)
+    return source
+
+
+def _resolve_module_key(record: object) -> str | None:
+    """
+    title: Return the best-effort module attribution of an irx diagnostic.
+    parameters:
+      record:
+        type: object
+    returns:
+      type: str | None
+    """
+    resolver = getattr(record, "resolved_module_key", None)
+    if callable(resolver):
+        module_key = resolver()
+    else:
+        module_key = getattr(record, "module_key", None)
+    return None if module_key is None else str(module_key)
+
+
+def _from_irx(
+    record: object,
+    *,
+    filename: str | None = None,
+) -> Diagnostic:
+    """
+    title: Translate one irx structured diagnostic into a PyArx Diagnostic.
+    summary: >-
+      Reads the upstream record by attribute so it accepts any irx.diagnostics
+      Diagnostic without importing irx, and discards the astx.AST node
+      reference. The current irx SourceLocation carries no filename, so the
+      attribution falls back to an explicit filename, then the diagnostic's
+      module key, then "<unknown>".
+    parameters:
+      record:
+        type: object
+      filename:
+        type: str | None
+    returns:
+      type: Diagnostic
+    """
+    source = _resolve_source(record)
+    code = getattr(record, "code", None)
+    attribution = filename or _resolve_module_key(record) or "<unknown>"
+    return Diagnostic(
+        severity=_coerce_severity(getattr(record, "severity", "error")),
+        message=str(getattr(record, "message", record)),
+        filename=attribution,
+        line=getattr(source, "line", None),
+        column=getattr(source, "col", None),
+        code=None if code is None else str(code),
+    )
+
+
+def _from_parser_exception(
+    exc: object,
+    *,
+    filename: str = "<string>",
+) -> Diagnostic:
+    """
+    title: Translate an arx ParserException into a PyArx Diagnostic.
+    summary: >-
+      ParserException.__init__ discards the offending token's location, so line
+      and column are None by design rather than fabricated.
+    parameters:
+      exc:
+        type: object
+      filename:
+        type: str
+    returns:
+      type: Diagnostic
+    """
+    return Diagnostic(
+        severity=DiagnosticSeverity.ERROR,
+        message=str(exc),
+        filename=filename,
+        line=None,
+        column=None,
+    )
+
+
+__all__ = [
+    "Diagnostic",
+    "DiagnosticSeverity",
+]

--- a/packages/pyarx/src/pyarx/errors.py
+++ b/packages/pyarx/src/pyarx/errors.py
@@ -1,0 +1,93 @@
+"""
+title: Public exception hierarchy for the PyArx API.
+summary: >-
+  Define the single error hierarchy PyArx raises to callers: ArxError as the
+  base, with ParseError, CompileError, and RuntimeError for the lex/parse,
+  analysis/lowering, and execution stages of the pipeline. Each error carries a
+  list of structured Diagnostic records so callers can inspect failures
+  programmatically instead of scraping message text. The pipeline modules catch
+  upstream arx and irx exceptions and re-raise them as these types, building
+  diagnostics via the helpers in pyarx.diagnostics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from pyarx.diagnostics import Diagnostic
+
+
+class ArxError(Exception):
+    """
+    title: Base class for every error raised by the PyArx API.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+        description: Structured diagnostics describing the failure.
+    """
+
+    diagnostics: list[Diagnostic]
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        diagnostics: Sequence[Diagnostic] | None = None,
+    ) -> None:
+        """
+        title: Initialize an ArxError.
+        parameters:
+          message:
+            type: str
+          diagnostics:
+            type: Sequence[Diagnostic] | None
+        """
+        self.diagnostics = list(diagnostics or ())
+        super().__init__(message)
+
+
+class ParseError(ArxError):
+    """
+    title: Raised when lexing or parsing Arx source fails.
+    summary: >-
+      Parser-origin diagnostics have no line or column in v1 because
+      ParserException discards token location.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+    """
+
+
+class CompileError(ArxError):
+    """
+    title: >-
+      Raised when semantic analysis, lowering, native compile, or linking
+      fails.
+    summary: >-
+      Carries the structured diagnostics from the irx error family, which
+      include source locations for most phases.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+    """
+
+
+class RuntimeError(ArxError):
+    """
+    title: Raised when running a compiled Arx program fails to execute.
+    summary: >-
+      Reserved for failures that prevent execution from completing, such as a
+      missing binary or a timeout. A program that runs to completion with a
+      non-zero exit code is reported as data, not raised.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+    """
+
+
+__all__ = [
+    "ArxError",
+    "CompileError",
+    "ParseError",
+    "RuntimeError",
+]

--- a/packages/pyarx/src/pyarx/errors.py
+++ b/packages/pyarx/src/pyarx/errors.py
@@ -2,7 +2,7 @@
 title: Public exception hierarchy for the PyArx API.
 summary: >-
   Define the single error hierarchy PyArx raises to callers: ArxError as the
-  base, with ParseError, CompileError, and RuntimeError for the lex/parse,
+  base, with ParseError, CompileError, and ExecutionError for the lex/parse,
   analysis/lowering, and execution stages of the pipeline. Each error carries a
   list of structured Diagnostic records so callers can inspect failures
   programmatically instead of scraping message text. The pipeline modules catch
@@ -72,7 +72,7 @@ class CompileError(ArxError):
     """
 
 
-class RuntimeError(ArxError):
+class ExecutionError(ArxError):
     """
     title: Raised when running a compiled Arx program fails to execute.
     summary: >-
@@ -88,6 +88,6 @@ class RuntimeError(ArxError):
 __all__ = [
     "ArxError",
     "CompileError",
+    "ExecutionError",
     "ParseError",
-    "RuntimeError",
 ]


### PR DESCRIPTION
## Summary

This is the first half of the pyarx error & diagnostic layer. I split the original change in two so the review stays manageable: this PR is just the source (~280 lines), and the unit tests + lint config land in a follow-up
stacked on top of it.

There are two new modules:

`diagnostics.py` exposes what callers actually inspect when something goes wrong. `DiagnosticSeverity` is a small enum (`ERROR`, `WARNING`, `INFO`,`HINT`) so severity is a real type instead of a bare string, and `Diagnostic` is a frozen value record with six fields: `severity`, `message`, `filename`, `line`, `column`, `code`. The two translators (`_from_irx` and `_from_parser_exception`) are private and read the upstream records by attribute rather than importing anything, which keeps two properties we  care about: the module doesn't drag in `arx`/`irx` at import time, and the raw `astx.AST` node on an irx record never leaks out into the public `Diagnostic`.

`errors.py` is the exception hierarchy callers catch: `ArxError` as the base, with `ParseError`, `CompileError`, and `RuntimeError` under it, each carrying a `list[Diagnostic]` that defaults to empty. There's deliberately no
translation logic here — turning an upstream `arx`/`irx` exception into one of these happens at the catch sites in `compiler.py`/`runtime.py` (later PRs), not on the exception classes.

`__init__.py` re-exports the six public names so `from pyarx import ParseError, Diagnostic, ...` works.

`import pyarx` stays free of the LLVM toolchain , I checked that neither `llvmlite` nor `arx` shows up in `sys.modules` after the import. ruff, ruff-format, and mypy (strict) are all clean.

The follow-up PR adds the tests (`test_diagnostics.py`, `test_errors.py`)
and the ruff config they need.
