### PR TITLE
record batch streaming via Arrow C++ bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,8 @@ PLAN.md
 # tmp
 pytest-*
 tmp*.makim
+
+# record_batch native build artifacts (compiled on demand by tests)
+packages/irx/src/irx/builder/runtime/arrow/native/_build/
+packages/irx/src/irx/builder/runtime/arrow/libirx_record_batch.*
+packages/irx/src/irx/builder/runtime/arrow/irx_record_batch.dll

--- a/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.cpp
+++ b/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.cpp
@@ -206,22 +206,9 @@ int irx_rb_builder_create(const IrxRbSchema *schema, IrxRbBuilder **out) {
     return IRX_OK;
 }
 
-/* Macro to generate typed append helpers */
-#define APPEND_IMPL(fname, ctype, arrowtype)                                \
-int fname(IrxRbBuilder *b, int col, ctype v) {                             \
-    GUARD(b);                                                               \
-    if (col < 0 || col >= (int)b->builders.size())                         \
-        return set_err("column index out of bounds", IRX_ERR_OOB);         \
-    if (b->schema_ref->col_types[col] != arrowtype)                        \
-        return set_err("type mismatch on append", IRX_ERR_TYPE);           \
-    auto *bldr = static_cast<arrow::arrowtype##Builder *>(                 \
-        b->builders[col].get());                                            \
-    auto st = bldr->Append(v);                                              \
-    if (!st.ok()) return set_err(st);                                       \
-    return IRX_OK;                                                          \
-}
-
-/* Specialised because Arrow uses Int8Builder not INT8Builder */
+/* Append helpers are written out longhand: Arrow builder class names
+ * (Int8Builder, FloatBuilder, …) do not map mechanically from IrxColumnType,
+ * so a token-pasting macro cannot cover every case cleanly. */
 int irx_rb_builder_append_int8(IrxRbBuilder *b, int col, int8_t v) {
     GUARD(b);
     if (col < 0 || col >= (int)b->builders.size())
@@ -448,11 +435,21 @@ int irx_rb_batch_value_buffer(const IrxRbBatch *b, int col,
     GUARD(b); GUARD(buf); GUARD(len);
     if (col < 0 || col >= b->batch->num_columns())
         return set_err("column index out of bounds", IRX_ERR_OOB);
-    auto &arr = b->batch->column(col);
+    auto arr = b->batch->column(col);
+    auto &data = *arr->data();
     /* Buffer 1 is the value buffer for fixed-width types. */
-    if (arr->data()->buffers.size() < 2 || !arr->data()->buffers[1])
+    if (data.buffers.size() < 2 || !data.buffers[1])
         return set_err("column has no value buffer (variable-width type?)", IRX_ERR_TYPE);
-    *buf = arr->data()->buffers[1]->data();
+    /* Account for a non-zero logical offset (sliced arrays): the value buffer
+     * starts before the array's first logical element. Advance by
+     * offset * byte_width so the returned pointer aligns with element 0. */
+    const auto *type = arr->type().get();
+    const auto *fw = dynamic_cast<const arrow::FixedWidthType *>(type);
+    if (fw == nullptr)
+        return set_err("column is not a fixed-width type", IRX_ERR_TYPE);
+    const int64_t byte_width = fw->bit_width() / 8;
+    const uint8_t *base = data.buffers[1]->data();
+    *buf = base + data.offset * byte_width;
     *len = arr->length();
     return IRX_OK;
 }
@@ -568,7 +565,16 @@ static int open_stream_reader(std::shared_ptr<arrow::io::InputStream> stream,
     r->schema_handle.schema       = arrow_schema;
     r->schema_handle.reader_owned = true;
     for (int i = 0; i < arrow_schema->num_fields(); ++i) {
-        auto ct = col_type_from_arrow(*arrow_schema->field(i)->type());
+        auto &field = *arrow_schema->field(i);
+        auto ct = col_type_from_arrow(*field.type());
+        if (static_cast<int>(ct) < 0) {
+            delete r;
+            return set_err(
+                "stream column '" + field.name() + "' has type '" +
+                    field.type()->ToString() +
+                    "' which is not supported by this reader",
+                IRX_ERR_TYPE);
+        }
         r->schema_handle.col_types.push_back(ct);
     }
 
@@ -588,7 +594,14 @@ int irx_rb_stream_reader_open_buffer(const uint8_t      *data,
                                       int64_t             size,
                                       IrxRbStreamReader **out) {
     GUARD(data); GUARD(out);
-    auto buf   = std::make_shared<arrow::Buffer>(data, size);
+    /* Copy the caller's bytes into an Arrow-owned buffer so the reader (and
+     * any batches it yields) stay valid regardless of the caller's buffer
+     * lifetime. Avoids a use-after-free when the source bytes are freed
+     * before the reader is closed. */
+    auto buf_res = arrow::AllocateBuffer(size);
+    if (!buf_res.ok()) return set_err(buf_res.status(), IRX_ERR_IO);
+    std::shared_ptr<arrow::Buffer> buf = std::move(*buf_res);
+    if (size > 0) std::memcpy(buf->mutable_data(), data, size);
     auto stream = std::make_shared<arrow::io::BufferReader>(buf);
     return open_stream_reader(stream, out);
 }

--- a/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.cpp
+++ b/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.cpp
@@ -1,0 +1,620 @@
+/**
+ * irx_record_batch.cpp
+ *
+ * Implementation of the RecordBatch streaming bridge declared in
+ * irx_record_batch.h. All Arrow C++ types are confined to this translation
+ * unit; the public surface is a pure C ABI.
+ *
+ * Build notes
+ * -----------
+ * Compiled as part of the `record_batch` runtime feature registered in
+ * packages/irx/src/irx/builder/runtime/registry.py.  The arx-arrowcpp-sources
+ * package provides the Arrow C++ headers used here.
+ */
+
+#include "irx_record_batch.h"
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/ipc/api.h>
+#include <arrow/result.h>
+#include <arrow/status.h>
+#include <arrow/type.h>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+/* ------------------------------------------------------------------ */
+/* Thread-local error message                                           */
+/* ------------------------------------------------------------------ */
+
+static thread_local std::string tl_errmsg;
+
+static int set_err(const std::string &msg, int code) {
+    tl_errmsg = msg;
+    return code;
+}
+
+static int set_err(const arrow::Status &st, int code = IRX_ERR_ARROW) {
+    tl_errmsg = st.ToString();
+    return code;
+}
+
+const char *irx_record_batch_errmsg(void) {
+    return tl_errmsg.c_str();
+}
+
+/* ------------------------------------------------------------------ */
+/* Internal helpers: Arrow type from IrxColumnType                     */
+/* ------------------------------------------------------------------ */
+
+static std::shared_ptr<arrow::DataType> arrow_type(IrxColumnType t) {
+    switch (t) {
+    case IRX_COL_INT8:    return arrow::int8();
+    case IRX_COL_INT16:   return arrow::int16();
+    case IRX_COL_INT32:   return arrow::int32();
+    case IRX_COL_INT64:   return arrow::int64();
+    case IRX_COL_UINT8:   return arrow::uint8();
+    case IRX_COL_UINT16:  return arrow::uint16();
+    case IRX_COL_UINT32:  return arrow::uint32();
+    case IRX_COL_UINT64:  return arrow::uint64();
+    case IRX_COL_FLOAT32: return arrow::float32();
+    case IRX_COL_FLOAT64: return arrow::float64();
+    case IRX_COL_BOOL:    return arrow::boolean();
+    }
+    return nullptr;
+}
+
+static IrxColumnType col_type_from_arrow(const arrow::DataType &dt) {
+    switch (dt.id()) {
+    case arrow::Type::INT8:    return IRX_COL_INT8;
+    case arrow::Type::INT16:   return IRX_COL_INT16;
+    case arrow::Type::INT32:   return IRX_COL_INT32;
+    case arrow::Type::INT64:   return IRX_COL_INT64;
+    case arrow::Type::UINT8:   return IRX_COL_UINT8;
+    case arrow::Type::UINT16:  return IRX_COL_UINT16;
+    case arrow::Type::UINT32:  return IRX_COL_UINT32;
+    case arrow::Type::UINT64:  return IRX_COL_UINT64;
+    case arrow::Type::FLOAT:   return IRX_COL_FLOAT32;
+    case arrow::Type::DOUBLE:  return IRX_COL_FLOAT64;
+    case arrow::Type::BOOL:    return IRX_COL_BOOL;
+    default:                   return static_cast<IrxColumnType>(-1);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* Internal structures behind opaque handles                           */
+/* ------------------------------------------------------------------ */
+
+struct IrxRbSchema_ {
+    std::shared_ptr<arrow::Schema>             schema;
+    std::vector<IrxColumnType>                 col_types;
+    /* Parallel vector used by the reader-side schema handle (owned). */
+    bool                                       reader_owned{false};
+};
+
+struct IrxRbBuilder_ {
+    const IrxRbSchema_                        *schema_ref;
+    std::vector<std::unique_ptr<arrow::ArrayBuilder>> builders;
+};
+
+struct IrxRbBatch_ {
+    std::shared_ptr<arrow::RecordBatch>        batch;
+    /* Cached col_types mirrored from the schema for fast type checks. */
+    std::vector<IrxColumnType>                 col_types;
+};
+
+struct IrxRbStreamWriter_ {
+    std::shared_ptr<arrow::io::OutputStream>   sink;
+    std::shared_ptr<arrow::ipc::RecordBatchWriter> writer;
+    /* For buffer-based writers. */
+    std::shared_ptr<arrow::io::BufferOutputStream> buf_sink;
+    bool                                       closed{false};
+    /* Cached serialised bytes (valid after close for buffer writers). */
+    std::shared_ptr<arrow::Buffer>             finished_buf;
+};
+
+struct IrxRbStreamReader_ {
+    std::shared_ptr<arrow::ipc::RecordBatchStreamReader> reader;
+    /* Schema handle exposed to callers (not released by caller). */
+    IrxRbSchema_                               schema_handle;
+};
+
+/* ------------------------------------------------------------------ */
+/* Null-pointer guard                                                   */
+/* ------------------------------------------------------------------ */
+#define GUARD(ptr) \
+    do { if (!(ptr)) return set_err("null pointer argument", IRX_ERR_NULLPTR); } while (0)
+
+/* ------------------------------------------------------------------ */
+/* Schema                                                               */
+/* ------------------------------------------------------------------ */
+
+int irx_rb_schema_create(IrxRbSchema **out) {
+    GUARD(out);
+    *out = new IrxRbSchema_();
+    (*out)->schema = arrow::schema({});
+    return IRX_OK;
+}
+
+int irx_rb_schema_add_field(IrxRbSchema *s,
+                             const char  *name,
+                             IrxColumnType type,
+                             int           nullable) {
+    GUARD(s); GUARD(name);
+    auto dt = arrow_type(type);
+    if (!dt)
+        return set_err("unknown IrxColumnType", IRX_ERR_TYPE);
+
+    auto field = arrow::field(name, dt, nullable != 0);
+    auto new_schema = s->schema->AddField(s->schema->num_fields(), field);
+    if (!new_schema.ok())
+        return set_err(new_schema.status());
+    s->schema = *new_schema;
+    s->col_types.push_back(type);
+    return IRX_OK;
+}
+
+int irx_rb_schema_num_fields(const IrxRbSchema *s) {
+    if (!s) return IRX_ERR_NULLPTR;
+    return s->schema->num_fields();
+}
+
+void irx_rb_schema_release(IrxRbSchema *s) {
+    delete s;
+}
+
+/* ------------------------------------------------------------------ */
+/* Builder                                                              */
+/* ------------------------------------------------------------------ */
+
+static std::unique_ptr<arrow::ArrayBuilder>
+make_builder(IrxColumnType t, arrow::MemoryPool *pool) {
+    std::unique_ptr<arrow::ArrayBuilder> b;
+    switch (t) {
+    case IRX_COL_INT8:    b = std::make_unique<arrow::Int8Builder>(pool);    break;
+    case IRX_COL_INT16:   b = std::make_unique<arrow::Int16Builder>(pool);   break;
+    case IRX_COL_INT32:   b = std::make_unique<arrow::Int32Builder>(pool);   break;
+    case IRX_COL_INT64:   b = std::make_unique<arrow::Int64Builder>(pool);   break;
+    case IRX_COL_UINT8:   b = std::make_unique<arrow::UInt8Builder>(pool);   break;
+    case IRX_COL_UINT16:  b = std::make_unique<arrow::UInt16Builder>(pool);  break;
+    case IRX_COL_UINT32:  b = std::make_unique<arrow::UInt32Builder>(pool);  break;
+    case IRX_COL_UINT64:  b = std::make_unique<arrow::UInt64Builder>(pool);  break;
+    case IRX_COL_FLOAT32: b = std::make_unique<arrow::FloatBuilder>(pool);   break;
+    case IRX_COL_FLOAT64: b = std::make_unique<arrow::DoubleBuilder>(pool);  break;
+    case IRX_COL_BOOL:    b = std::make_unique<arrow::BooleanBuilder>(pool); break;
+    }
+    return b;
+}
+
+int irx_rb_builder_create(const IrxRbSchema *schema, IrxRbBuilder **out) {
+    GUARD(schema); GUARD(out);
+    auto *b = new IrxRbBuilder_();
+    b->schema_ref = schema;
+    auto *pool = arrow::default_memory_pool();
+    for (auto ct : schema->col_types) {
+        auto bldr = make_builder(ct, pool);
+        if (!bldr) {
+            delete b;
+            return set_err("failed to create column builder", IRX_ERR_ARROW);
+        }
+        b->builders.push_back(std::move(bldr));
+    }
+    *out = b;
+    return IRX_OK;
+}
+
+/* Macro to generate typed append helpers */
+#define APPEND_IMPL(fname, ctype, arrowtype)                                \
+int fname(IrxRbBuilder *b, int col, ctype v) {                             \
+    GUARD(b);                                                               \
+    if (col < 0 || col >= (int)b->builders.size())                         \
+        return set_err("column index out of bounds", IRX_ERR_OOB);         \
+    if (b->schema_ref->col_types[col] != arrowtype)                        \
+        return set_err("type mismatch on append", IRX_ERR_TYPE);           \
+    auto *bldr = static_cast<arrow::arrowtype##Builder *>(                 \
+        b->builders[col].get());                                            \
+    auto st = bldr->Append(v);                                              \
+    if (!st.ok()) return set_err(st);                                       \
+    return IRX_OK;                                                          \
+}
+
+/* Specialised because Arrow uses Int8Builder not INT8Builder */
+int irx_rb_builder_append_int8(IrxRbBuilder *b, int col, int8_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_INT8)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::Int8Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_int16(IrxRbBuilder *b, int col, int16_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_INT16)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::Int16Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_int32(IrxRbBuilder *b, int col, int32_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_INT32)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::Int32Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_int64(IrxRbBuilder *b, int col, int64_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_INT64)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::Int64Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_uint8(IrxRbBuilder *b, int col, uint8_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_UINT8)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::UInt8Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_uint16(IrxRbBuilder *b, int col, uint16_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_UINT16)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::UInt16Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_uint32(IrxRbBuilder *b, int col, uint32_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_UINT32)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::UInt32Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_uint64(IrxRbBuilder *b, int col, uint64_t v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_UINT64)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::UInt64Builder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_float32(IrxRbBuilder *b, int col, float v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_FLOAT32)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::FloatBuilder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_float64(IrxRbBuilder *b, int col, double v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_FLOAT64)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::DoubleBuilder *>(b->builders[col].get())->Append(v);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_bool(IrxRbBuilder *b, int col, int v) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    if (b->schema_ref->col_types[col] != IRX_COL_BOOL)
+        return set_err("type mismatch on append", IRX_ERR_TYPE);
+    auto st = static_cast<arrow::BooleanBuilder *>(b->builders[col].get())->Append(v != 0);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+int irx_rb_builder_append_null(IrxRbBuilder *b, int col) {
+    GUARD(b);
+    if (col < 0 || col >= (int)b->builders.size())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    auto st = b->builders[col]->AppendNull();
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+
+int irx_rb_builder_finish(IrxRbBuilder *b, IrxRbBatch **out) {
+    GUARD(b); GUARD(out);
+
+    /* Verify all columns have the same length. */
+    if (!b->builders.empty()) {
+        int64_t len = b->builders[0]->length();
+        for (size_t i = 1; i < b->builders.size(); ++i) {
+            if (b->builders[i]->length() != len)
+                return set_err("column length mismatch in RecordBatch", IRX_ERR_ARROW);
+        }
+    }
+
+    std::vector<std::shared_ptr<arrow::Array>> arrays;
+    arrays.reserve(b->builders.size());
+    for (auto &bldr : b->builders) {
+        std::shared_ptr<arrow::Array> arr;
+        auto st = bldr->Finish(&arr);
+        if (!st.ok()) return set_err(st);
+        arrays.push_back(std::move(arr));
+    }
+
+    auto rb = arrow::RecordBatch::Make(b->schema_ref->schema,
+                                        arrays.empty() ? 0 : arrays[0]->length(),
+                                        arrays);
+    auto *batch = new IrxRbBatch_();
+    batch->batch     = std::move(rb);
+    batch->col_types = b->schema_ref->col_types;
+    *out = batch;
+    return IRX_OK;
+}
+
+void irx_rb_builder_release(IrxRbBuilder *b) {
+    delete b;
+}
+
+/* ------------------------------------------------------------------ */
+/* RecordBatch inspection                                               */
+/* ------------------------------------------------------------------ */
+
+int64_t irx_rb_batch_num_rows(const IrxRbBatch *batch) {
+    if (!batch) return IRX_ERR_NULLPTR;
+    return batch->batch->num_rows();
+}
+
+int irx_rb_batch_num_columns(const IrxRbBatch *batch) {
+    if (!batch) return IRX_ERR_NULLPTR;
+    return batch->batch->num_columns();
+}
+
+/* Bounds-check helper — returns true and sets error on failure. */
+static bool check_bounds(const IrxRbBatch *b, int col, int64_t row) {
+    if (col < 0 || col >= b->batch->num_columns()) {
+        set_err("column index out of bounds", IRX_ERR_OOB);
+        return true;
+    }
+    if (row < 0 || row >= b->batch->num_rows()) {
+        set_err("row index out of bounds", IRX_ERR_OOB);
+        return true;
+    }
+    return false;
+}
+
+#define GET_IMPL(fname, ctype, arrowarray, irxtype)                         \
+int fname(const IrxRbBatch *b, int col, int64_t row, ctype *out) {        \
+    GUARD(b); GUARD(out);                                                   \
+    if (check_bounds(b, col, row)) return IRX_ERR_OOB;                     \
+    if (b->col_types[col] != irxtype)                                       \
+        return set_err("type mismatch on get", IRX_ERR_TYPE);               \
+    auto *arr = static_cast<const arrow::arrowarray *>(                     \
+        b->batch->column(col).get());                                       \
+    *out = arr->Value(row);                                                 \
+    return IRX_OK;                                                          \
+}
+
+GET_IMPL(irx_rb_batch_get_int8,    int8_t,   Int8Array,    IRX_COL_INT8)
+GET_IMPL(irx_rb_batch_get_int16,   int16_t,  Int16Array,   IRX_COL_INT16)
+GET_IMPL(irx_rb_batch_get_int32,   int32_t,  Int32Array,   IRX_COL_INT32)
+GET_IMPL(irx_rb_batch_get_int64,   int64_t,  Int64Array,   IRX_COL_INT64)
+GET_IMPL(irx_rb_batch_get_uint8,   uint8_t,  UInt8Array,   IRX_COL_UINT8)
+GET_IMPL(irx_rb_batch_get_uint16,  uint16_t, UInt16Array,  IRX_COL_UINT16)
+GET_IMPL(irx_rb_batch_get_uint32,  uint32_t, UInt32Array,  IRX_COL_UINT32)
+GET_IMPL(irx_rb_batch_get_uint64,  uint64_t, UInt64Array,  IRX_COL_UINT64)
+GET_IMPL(irx_rb_batch_get_float32, float,    FloatArray,   IRX_COL_FLOAT32)
+GET_IMPL(irx_rb_batch_get_float64, double,   DoubleArray,  IRX_COL_FLOAT64)
+
+int irx_rb_batch_get_bool(const IrxRbBatch *b, int col, int64_t row, int *out) {
+    GUARD(b); GUARD(out);
+    if (check_bounds(b, col, row)) return IRX_ERR_OOB;
+    if (b->col_types[col] != IRX_COL_BOOL)
+        return set_err("type mismatch on get", IRX_ERR_TYPE);
+    auto *arr = static_cast<const arrow::BooleanArray *>(b->batch->column(col).get());
+    *out = arr->Value(row) ? 1 : 0;
+    return IRX_OK;
+}
+
+int irx_rb_batch_is_null(const IrxRbBatch *b, int col, int64_t row, int *out) {
+    GUARD(b); GUARD(out);
+    if (check_bounds(b, col, row)) return IRX_ERR_OOB;
+    *out = b->batch->column(col)->IsNull(row) ? 1 : 0;
+    return IRX_OK;
+}
+
+int irx_rb_batch_value_buffer(const IrxRbBatch *b, int col,
+                               const void **buf, int64_t *len) {
+    GUARD(b); GUARD(buf); GUARD(len);
+    if (col < 0 || col >= b->batch->num_columns())
+        return set_err("column index out of bounds", IRX_ERR_OOB);
+    auto &arr = b->batch->column(col);
+    /* Buffer 1 is the value buffer for fixed-width types. */
+    if (arr->data()->buffers.size() < 2 || !arr->data()->buffers[1])
+        return set_err("column has no value buffer (variable-width type?)", IRX_ERR_TYPE);
+    *buf = arr->data()->buffers[1]->data();
+    *len = arr->length();
+    return IRX_OK;
+}
+
+void irx_rb_batch_release(IrxRbBatch *batch) {
+    delete batch;
+}
+
+/* ------------------------------------------------------------------ */
+/* Stream writer                                                        */
+/* ------------------------------------------------------------------ */
+
+int irx_rb_stream_writer_open_file(const IrxRbSchema   *schema,
+                                    const char          *path,
+                                    IrxRbStreamWriter  **out) {
+    GUARD(schema); GUARD(path); GUARD(out);
+
+    auto open_result = arrow::io::FileOutputStream::Open(path);
+    if (!open_result.ok()) return set_err(open_result.status(), IRX_ERR_IO);
+
+    auto sink = *open_result;
+    auto writer_result = arrow::ipc::MakeStreamWriter(sink, schema->schema);
+    if (!writer_result.ok()) return set_err(writer_result.status());
+
+    auto *w = new IrxRbStreamWriter_();
+    w->sink   = sink;
+    w->writer = *writer_result;
+    *out = w;
+    return IRX_OK;
+}
+
+int irx_rb_stream_writer_open_buffer(const IrxRbSchema   *schema,
+                                      IrxRbStreamWriter  **out) {
+    GUARD(schema); GUARD(out);
+
+    auto buf_sink_result = arrow::io::BufferOutputStream::Create();
+    if (!buf_sink_result.ok()) return set_err(buf_sink_result.status(), IRX_ERR_IO);
+
+    auto buf_sink = *buf_sink_result;
+    auto writer_result = arrow::ipc::MakeStreamWriter(buf_sink, schema->schema);
+    if (!writer_result.ok()) return set_err(writer_result.status());
+
+    auto *w = new IrxRbStreamWriter_();
+    w->buf_sink = buf_sink;
+    w->sink     = buf_sink;
+    w->writer   = *writer_result;
+    *out = w;
+    return IRX_OK;
+}
+
+int irx_rb_stream_writer_write_batch(IrxRbStreamWriter *w,
+                                      const IrxRbBatch  *batch) {
+    GUARD(w); GUARD(batch);
+    if (w->closed) return set_err("writer already closed", IRX_ERR_IO);
+    auto st = w->writer->WriteRecordBatch(*batch->batch);
+    if (!st.ok()) return set_err(st);
+    return IRX_OK;
+}
+
+int irx_rb_stream_writer_close(IrxRbStreamWriter *w) {
+    GUARD(w);
+    if (w->closed) return IRX_OK;
+    auto st = w->writer->Close();
+    if (!st.ok()) return set_err(st);
+    if (w->buf_sink) {
+        auto buf_result = w->buf_sink->Finish();
+        if (!buf_result.ok()) return set_err(buf_result.status(), IRX_ERR_IO);
+        w->finished_buf = *buf_result;
+    } else {
+        auto st2 = w->sink->Close();
+        if (!st2.ok()) return set_err(st2, IRX_ERR_IO);
+    }
+    w->closed = true;
+    return IRX_OK;
+}
+
+int irx_rb_stream_writer_buffer_data(const IrxRbStreamWriter *w,
+                                      const uint8_t **data,
+                                      int64_t        *size) {
+    GUARD(w); GUARD(data); GUARD(size);
+    if (!w->closed)
+        return set_err("writer not yet closed; call irx_rb_stream_writer_close first",
+                       IRX_ERR_IO);
+    if (!w->buf_sink || !w->finished_buf)
+        return set_err("writer is file-based, not buffer-based", IRX_ERR_IO);
+    *data = w->finished_buf->data();
+    *size = w->finished_buf->size();
+    return IRX_OK;
+}
+
+void irx_rb_stream_writer_release(IrxRbStreamWriter *w) {
+    if (!w) return;
+    if (!w->closed && w->writer) {
+        (void)w->writer->Close();
+    }
+    delete w;
+}
+
+/* ------------------------------------------------------------------ */
+/* Stream reader                                                        */
+/* ------------------------------------------------------------------ */
+
+static int open_stream_reader(std::shared_ptr<arrow::io::InputStream> stream,
+                               IrxRbStreamReader **out) {
+    auto reader_result = arrow::ipc::RecordBatchStreamReader::Open(stream);
+    if (!reader_result.ok()) return set_err(reader_result.status());
+
+    auto *r = new IrxRbStreamReader_();
+    r->reader = *reader_result;
+
+    /* Populate the schema handle from the stream schema. */
+    auto arrow_schema = r->reader->schema();
+    r->schema_handle.schema       = arrow_schema;
+    r->schema_handle.reader_owned = true;
+    for (int i = 0; i < arrow_schema->num_fields(); ++i) {
+        auto ct = col_type_from_arrow(*arrow_schema->field(i)->type());
+        r->schema_handle.col_types.push_back(ct);
+    }
+
+    *out = r;
+    return IRX_OK;
+}
+
+int irx_rb_stream_reader_open_file(const char         *path,
+                                    IrxRbStreamReader **out) {
+    GUARD(path); GUARD(out);
+    auto open_result = arrow::io::ReadableFile::Open(path);
+    if (!open_result.ok()) return set_err(open_result.status(), IRX_ERR_IO);
+    return open_stream_reader(*open_result, out);
+}
+
+int irx_rb_stream_reader_open_buffer(const uint8_t      *data,
+                                      int64_t             size,
+                                      IrxRbStreamReader **out) {
+    GUARD(data); GUARD(out);
+    auto buf   = std::make_shared<arrow::Buffer>(data, size);
+    auto stream = std::make_shared<arrow::io::BufferReader>(buf);
+    return open_stream_reader(stream, out);
+}
+
+int irx_rb_stream_reader_next_batch(IrxRbStreamReader *r,
+                                     IrxRbBatch       **batch) {
+    GUARD(r); GUARD(batch);
+    std::shared_ptr<arrow::RecordBatch> rb;
+    auto st = r->reader->ReadNext(&rb);
+    if (!st.ok()) return set_err(st);
+    if (!rb) {
+        *batch = nullptr;
+        return IRX_EOF;
+    }
+    auto *b = new IrxRbBatch_();
+    b->batch     = std::move(rb);
+    b->col_types = r->schema_handle.col_types;
+    *batch = b;
+    return IRX_OK;
+}
+
+const IrxRbSchema *irx_rb_stream_reader_schema(const IrxRbStreamReader *r) {
+    if (!r) return nullptr;
+    return &r->schema_handle;
+}
+
+void irx_rb_stream_reader_close(IrxRbStreamReader *r) {
+    delete r;
+}

--- a/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.cpp
+++ b/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.cpp
@@ -1,16 +1,4 @@
-/**
- * irx_record_batch.cpp
- *
- * Implementation of the RecordBatch streaming bridge declared in
- * irx_record_batch.h. All Arrow C++ types are confined to this translation
- * unit; the public surface is a pure C ABI.
- *
- * Build notes
- * -----------
- * Compiled as part of the `record_batch` runtime feature registered in
- * packages/irx/src/irx/builder/runtime/registry.py.  The arx-arrowcpp-sources
- * package provides the Arrow C++ headers used here.
- */
+// Copyright IRx contributors.
 
 #include "irx_record_batch.h"
 
@@ -26,10 +14,6 @@
 #include <string>
 #include <vector>
 
-/* ------------------------------------------------------------------ */
-/* Thread-local error message                                           */
-/* ------------------------------------------------------------------ */
-
 static thread_local std::string tl_errmsg;
 
 static int set_err(const std::string &msg, int code) {
@@ -43,12 +27,14 @@ static int set_err(const arrow::Status &st, int code = IRX_ERR_ARROW) {
 }
 
 const char *irx_record_batch_errmsg(void) {
-    return tl_errmsg.c_str();
+    // Hand the message to a holder and clear the live buffer, so a second
+    // read (with no error in between) returns "" instead of a stale message.
+    // The holder keeps the returned pointer valid until the next read.
+    static thread_local std::string consumed;
+    consumed = std::move(tl_errmsg);
+    tl_errmsg.clear();
+    return consumed.c_str();
 }
-
-/* ------------------------------------------------------------------ */
-/* Internal helpers: Arrow type from IrxColumnType                     */
-/* ------------------------------------------------------------------ */
 
 static std::shared_ptr<arrow::DataType> arrow_type(IrxColumnType t) {
     switch (t) {
@@ -84,10 +70,6 @@ static IrxColumnType col_type_from_arrow(const arrow::DataType &dt) {
     }
 }
 
-/* ------------------------------------------------------------------ */
-/* Internal structures behind opaque handles                           */
-/* ------------------------------------------------------------------ */
-
 struct IrxRbSchema_ {
     std::shared_ptr<arrow::Schema>             schema;
     std::vector<IrxColumnType>                 col_types;
@@ -122,15 +104,8 @@ struct IrxRbStreamReader_ {
     IrxRbSchema_                               schema_handle;
 };
 
-/* ------------------------------------------------------------------ */
-/* Null-pointer guard                                                   */
-/* ------------------------------------------------------------------ */
 #define GUARD(ptr) \
     do { if (!(ptr)) return set_err("null pointer argument", IRX_ERR_NULLPTR); } while (0)
-
-/* ------------------------------------------------------------------ */
-/* Schema                                                               */
-/* ------------------------------------------------------------------ */
 
 int irx_rb_schema_create(IrxRbSchema **out) {
     GUARD(out);
@@ -165,10 +140,6 @@ int irx_rb_schema_num_fields(const IrxRbSchema *s) {
 void irx_rb_schema_release(IrxRbSchema *s) {
     delete s;
 }
-
-/* ------------------------------------------------------------------ */
-/* Builder                                                              */
-/* ------------------------------------------------------------------ */
 
 static std::unique_ptr<arrow::ArrayBuilder>
 make_builder(IrxColumnType t, arrow::MemoryPool *pool) {
@@ -363,10 +334,6 @@ void irx_rb_builder_release(IrxRbBuilder *b) {
     delete b;
 }
 
-/* ------------------------------------------------------------------ */
-/* RecordBatch inspection                                               */
-/* ------------------------------------------------------------------ */
-
 int64_t irx_rb_batch_num_rows(const IrxRbBatch *batch) {
     if (!batch) return IRX_ERR_NULLPTR;
     return batch->batch->num_rows();
@@ -458,10 +425,6 @@ void irx_rb_batch_release(IrxRbBatch *batch) {
     delete batch;
 }
 
-/* ------------------------------------------------------------------ */
-/* Stream writer                                                        */
-/* ------------------------------------------------------------------ */
-
 int irx_rb_stream_writer_open_file(const IrxRbSchema   *schema,
                                     const char          *path,
                                     IrxRbStreamWriter  **out) {
@@ -548,10 +511,6 @@ void irx_rb_stream_writer_release(IrxRbStreamWriter *w) {
     delete w;
 }
 
-/* ------------------------------------------------------------------ */
-/* Stream reader                                                        */
-/* ------------------------------------------------------------------ */
-
 static int open_stream_reader(std::shared_ptr<arrow::io::InputStream> stream,
                                IrxRbStreamReader **out) {
     auto reader_result = arrow::ipc::RecordBatchStreamReader::Open(stream);
@@ -601,7 +560,7 @@ int irx_rb_stream_reader_open_buffer(const uint8_t      *data,
     auto buf_res = arrow::AllocateBuffer(size);
     if (!buf_res.ok()) return set_err(buf_res.status(), IRX_ERR_IO);
     std::shared_ptr<arrow::Buffer> buf = std::move(*buf_res);
-    if (size > 0) std::memcpy(buf->mutable_data(), data, size);
+    if (size > 0) std::memcpy(const_cast<uint8_t*>(buf->data()), data, size);
     auto stream = std::make_shared<arrow::io::BufferReader>(buf);
     return open_stream_reader(stream, out);
 }

--- a/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.h
+++ b/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.h
@@ -1,42 +1,7 @@
-/**
- * irx_record_batch.h
- *
- * Public C ABI for RecordBatch streaming via the Arrow C++ bridge.
- *
- * This header is the ONLY surface that compiled Arx programs (or other native
- * callers) may use. Every handle is opaque; the Arrow C++ types never leak
- * across the boundary. All functions return IRX_OK (0) on success or a
- * negative IRX_ERR_* code on failure. The last error message for the current
- * thread can be retrieved with irx_record_batch_errmsg().
- *
- * Lifecycle contract
- * ------------------
- *  1. Create a schema with irx_rb_schema_create().
- *  2. Add fields to the schema with irx_rb_schema_add_field().
- *  3. Open a stream writer with irx_rb_stream_writer_open_file() or
- *     irx_rb_stream_writer_open_buffer().
- *  4. For each batch:
- *       a. irx_rb_builder_create()   -- allocate a builder
- *       b. irx_rb_builder_append_*() -- push values per column
- *       c. irx_rb_builder_finish()   -- materialise the RecordBatch
- *       d. irx_rb_stream_writer_write_batch()
- *       e. irx_rb_batch_release()    -- drop the batch handle
- *       f. irx_rb_builder_release()  -- drop the builder handle
- *  5. irx_rb_stream_writer_close()
- *  6. irx_rb_schema_release()
- *
- * Reading
- * -------
- *  1. irx_rb_stream_reader_open_file() / irx_rb_stream_reader_open_buffer()
- *  2. irx_rb_stream_reader_next_batch() in a loop until it returns
- *     IRX_EOF (1).
- *  3. Inspect the batch with irx_rb_batch_num_rows() /
- *     irx_rb_batch_column_int32() etc.
- *  4. irx_rb_batch_release() per batch.
- *  5. irx_rb_stream_reader_close().
- */
+// Copyright IRx contributors.
 
-#pragma once
+#ifndef IRX_RECORD_BATCH_H_INCLUDED
+#define IRX_RECORD_BATCH_H_INCLUDED
 
 #include <stddef.h>
 #include <stdint.h>
@@ -45,20 +10,14 @@
 extern "C" {
 #endif
 
-/* ------------------------------------------------------------------ */
-/* Return codes                                                         */
-/* ------------------------------------------------------------------ */
 #define IRX_OK       0
 #define IRX_EOF      1   /* non-error: reader has no more batches */
 #define IRX_ERR_ARROW   -1
 #define IRX_ERR_NULLPTR -2
-#define IRX_ERR_OOB     -3  /* column / row index out of bounds   */
-#define IRX_ERR_TYPE    -4  /* type mismatch                      */
+#define IRX_ERR_OOB     -3  /* column / row index out of bounds */
+#define IRX_ERR_TYPE    -4  /* type mismatch */
 #define IRX_ERR_IO      -5
 
-/* ------------------------------------------------------------------ */
-/* Column storage types (mirrors irx_arrow.h primitive set)            */
-/* ------------------------------------------------------------------ */
 typedef enum IrxColumnType {
     IRX_COL_INT8    = 0,
     IRX_COL_INT16   = 1,
@@ -73,58 +32,23 @@ typedef enum IrxColumnType {
     IRX_COL_BOOL    = 10,
 } IrxColumnType;
 
-/* ------------------------------------------------------------------ */
-/* Opaque handle types                                                  */
-/* ------------------------------------------------------------------ */
 typedef struct IrxRbSchema_       IrxRbSchema;
 typedef struct IrxRbBuilder_      IrxRbBuilder;
 typedef struct IrxRbBatch_        IrxRbBatch;
 typedef struct IrxRbStreamWriter_ IrxRbStreamWriter;
 typedef struct IrxRbStreamReader_ IrxRbStreamReader;
 
-/* ------------------------------------------------------------------ */
-/* Error reporting                                                      */
-/* ------------------------------------------------------------------ */
-
-/** Return the last error message for the calling thread (never NULL). */
 const char *irx_record_batch_errmsg(void);
 
-/* ------------------------------------------------------------------ */
-/* Schema                                                               */
-/* ------------------------------------------------------------------ */
-
-/**
- * Create an empty schema. Caller must call irx_rb_schema_release() when done.
- * @param[out] out  receives the new schema handle.
- */
 int irx_rb_schema_create(IrxRbSchema **out);
-
-/**
- * Add a named field to the schema.
- * @param nullable  non-zero = field may contain nulls.
- */
 int irx_rb_schema_add_field(IrxRbSchema *schema,
                              const char  *name,
                              IrxColumnType type,
                              int           nullable);
-
-/** Return the number of fields in the schema. */
 int irx_rb_schema_num_fields(const IrxRbSchema *schema);
-
-/** Release the schema handle and free resources. */
 void irx_rb_schema_release(IrxRbSchema *schema);
 
-/* ------------------------------------------------------------------ */
-/* Builder (one per batch)                                              */
-/* ------------------------------------------------------------------ */
-
-/**
- * Create a new builder for the given schema.
- * The schema must outlive the builder.
- */
 int irx_rb_builder_create(const IrxRbSchema *schema, IrxRbBuilder **out);
-
-/* Append helpers — col is a zero-based column index. */
 int irx_rb_builder_append_int8   (IrxRbBuilder *b, int col, int8_t   v);
 int irx_rb_builder_append_int16  (IrxRbBuilder *b, int col, int16_t  v);
 int irx_rb_builder_append_int32  (IrxRbBuilder *b, int col, int32_t  v);
@@ -137,32 +61,11 @@ int irx_rb_builder_append_float32(IrxRbBuilder *b, int col, float    v);
 int irx_rb_builder_append_float64(IrxRbBuilder *b, int col, double   v);
 int irx_rb_builder_append_bool   (IrxRbBuilder *b, int col, int      v);
 int irx_rb_builder_append_null   (IrxRbBuilder *b, int col);
-
-/**
- * Finalise the builder and produce a RecordBatch.
- * All columns must have the same length; otherwise IRX_ERR_ARROW is returned.
- * @param[out] out  receives the new batch handle.
- */
 int irx_rb_builder_finish(IrxRbBuilder *b, IrxRbBatch **out);
-
-/** Release the builder. May be called before or after finish(). */
 void irx_rb_builder_release(IrxRbBuilder *b);
 
-/* ------------------------------------------------------------------ */
-/* RecordBatch inspection                                               */
-/* ------------------------------------------------------------------ */
-
-/** Number of rows in the batch. */
 int64_t irx_rb_batch_num_rows(const IrxRbBatch *batch);
-
-/** Number of columns. */
 int irx_rb_batch_num_columns(const IrxRbBatch *batch);
-
-/**
- * Read a single value from a typed column by row index.
- * Returns IRX_ERR_OOB if row >= num_rows or col >= num_columns.
- * Returns IRX_ERR_TYPE if the column type does not match the accessor.
- */
 int irx_rb_batch_get_int8   (const IrxRbBatch *b, int col, int64_t row, int8_t   *out);
 int irx_rb_batch_get_int16  (const IrxRbBatch *b, int col, int64_t row, int16_t  *out);
 int irx_rb_batch_get_int32  (const IrxRbBatch *b, int col, int64_t row, int32_t  *out);
@@ -174,103 +77,36 @@ int irx_rb_batch_get_uint64 (const IrxRbBatch *b, int col, int64_t row, uint64_t
 int irx_rb_batch_get_float32(const IrxRbBatch *b, int col, int64_t row, float    *out);
 int irx_rb_batch_get_float64(const IrxRbBatch *b, int col, int64_t row, double   *out);
 int irx_rb_batch_get_bool   (const IrxRbBatch *b, int col, int64_t row, int      *out);
-
-/** True if the value at (col, row) is null. */
 int irx_rb_batch_is_null(const IrxRbBatch *b, int col, int64_t row, int *out);
-
-/**
- * Zero-copy read-only pointer to the raw value buffer of a fixed-width column.
- * The pointer is valid until irx_rb_batch_release() is called.
- * @param[out] buf   set to the start of the value buffer.
- * @param[out] len   number of elements (== num_rows for fixed-width types).
- */
 int irx_rb_batch_value_buffer(const IrxRbBatch *b, int col,
                                const void **buf, int64_t *len);
-
-/** Release the batch and free Arrow resources. */
 void irx_rb_batch_release(IrxRbBatch *batch);
 
-/* ------------------------------------------------------------------ */
-/* Stream writer                                                        */
-/* ------------------------------------------------------------------ */
-
-/**
- * Open an Arrow IPC stream writer to a file path.
- * Creates or truncates the file.
- */
 int irx_rb_stream_writer_open_file(const IrxRbSchema   *schema,
                                     const char          *path,
                                     IrxRbStreamWriter  **out);
-
-/**
- * Open an Arrow IPC stream writer to a growable in-memory buffer.
- * Retrieve the finished bytes with irx_rb_stream_writer_buffer_data() after
- * close.
- */
 int irx_rb_stream_writer_open_buffer(const IrxRbSchema   *schema,
                                       IrxRbStreamWriter  **out);
-
-/** Write one RecordBatch to the stream. */
 int irx_rb_stream_writer_write_batch(IrxRbStreamWriter *w,
                                       const IrxRbBatch  *batch);
-
-/**
- * Finalise and close the stream.  Must be called before reading back a
- * buffer-based writer's bytes.
- */
 int irx_rb_stream_writer_close(IrxRbStreamWriter *w);
-
-/**
- * For buffer-based writers only: return a pointer to the serialised IPC bytes
- * and their length.  Valid only after irx_rb_stream_writer_close().
- * The pointer is owned by the writer and freed by irx_rb_stream_writer_release().
- */
 int irx_rb_stream_writer_buffer_data(const IrxRbStreamWriter *w,
                                       const uint8_t **data,
                                       int64_t        *size);
-
-/** Release the writer. Implicitly closes if not already closed. */
 void irx_rb_stream_writer_release(IrxRbStreamWriter *w);
 
-/* ------------------------------------------------------------------ */
-/* Stream reader                                                        */
-/* ------------------------------------------------------------------ */
-
-/**
- * Open an Arrow IPC stream reader from a file.
- * The schema embedded in the stream is used; the caller does not need to
- * supply one.
- */
 int irx_rb_stream_reader_open_file(const char         *path,
                                     IrxRbStreamReader **out);
-
-/**
- * Open an Arrow IPC stream reader from a byte buffer.
- * The bytes are copied into an Arrow-owned buffer, so the caller's buffer
- * does not need to outlive the reader.
- */
 int irx_rb_stream_reader_open_buffer(const uint8_t      *data,
                                       int64_t             size,
                                       IrxRbStreamReader **out);
-
-/**
- * Read the next RecordBatch from the stream.
- * Returns IRX_OK and sets *batch on success.
- * Returns IRX_EOF (1) when the stream is exhausted (*batch is set to NULL).
- * Returns a negative IRX_ERR_* on error.
- */
 int irx_rb_stream_reader_next_batch(IrxRbStreamReader *r,
                                      IrxRbBatch       **batch);
-
-/**
- * Return the schema advertised by the stream (do NOT release this pointer;
- * it is owned by the reader).
- */
 const IrxRbSchema *irx_rb_stream_reader_schema(const IrxRbStreamReader *r);
-
-/** Close and release the reader. */
 void irx_rb_stream_reader_close(IrxRbStreamReader *r);
 
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
+
+#endif /* IRX_RECORD_BATCH_H_INCLUDED */

--- a/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.h
+++ b/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.h
@@ -1,0 +1,275 @@
+/**
+ * irx_record_batch.h
+ *
+ * Public C ABI for RecordBatch streaming via the Arrow C++ bridge.
+ *
+ * This header is the ONLY surface that compiled Arx programs (or other native
+ * callers) may use. Every handle is opaque; the Arrow C++ types never leak
+ * across the boundary. All functions return IRX_OK (0) on success or a
+ * negative IRX_ERR_* code on failure. The last error message for the current
+ * thread can be retrieved with irx_record_batch_errmsg().
+ *
+ * Lifecycle contract
+ * ------------------
+ *  1. Create a schema with irx_rb_schema_create().
+ *  2. Add fields to the schema with irx_rb_schema_add_field().
+ *  3. Open a stream writer with irx_rb_stream_writer_open_file() or
+ *     irx_rb_stream_writer_open_buffer().
+ *  4. For each batch:
+ *       a. irx_rb_builder_create()   -- allocate a builder
+ *       b. irx_rb_builder_append_*() -- push values per column
+ *       c. irx_rb_builder_finish()   -- materialise the RecordBatch
+ *       d. irx_rb_stream_writer_write_batch()
+ *       e. irx_rb_batch_release()    -- drop the batch handle
+ *       f. irx_rb_builder_release()  -- drop the builder handle
+ *  5. irx_rb_stream_writer_close()
+ *  6. irx_rb_schema_release()
+ *
+ * Reading
+ * -------
+ *  1. irx_rb_stream_reader_open_file() / irx_rb_stream_reader_open_buffer()
+ *  2. irx_rb_stream_reader_next_batch() in a loop until it returns
+ *     IRX_EOF (1).
+ *  3. Inspect the batch with irx_rb_batch_num_rows() /
+ *     irx_rb_batch_column_int32() etc.
+ *  4. irx_rb_batch_release() per batch.
+ *  5. irx_rb_stream_reader_close().
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ------------------------------------------------------------------ */
+/* Return codes                                                         */
+/* ------------------------------------------------------------------ */
+#define IRX_OK       0
+#define IRX_EOF      1   /* non-error: reader has no more batches */
+#define IRX_ERR_ARROW   -1
+#define IRX_ERR_NULLPTR -2
+#define IRX_ERR_OOB     -3  /* column / row index out of bounds   */
+#define IRX_ERR_TYPE    -4  /* type mismatch                      */
+#define IRX_ERR_IO      -5
+
+/* ------------------------------------------------------------------ */
+/* Column storage types (mirrors irx_arrow.h primitive set)            */
+/* ------------------------------------------------------------------ */
+typedef enum IrxColumnType {
+    IRX_COL_INT8    = 0,
+    IRX_COL_INT16   = 1,
+    IRX_COL_INT32   = 2,
+    IRX_COL_INT64   = 3,
+    IRX_COL_UINT8   = 4,
+    IRX_COL_UINT16  = 5,
+    IRX_COL_UINT32  = 6,
+    IRX_COL_UINT64  = 7,
+    IRX_COL_FLOAT32 = 8,
+    IRX_COL_FLOAT64 = 9,
+    IRX_COL_BOOL    = 10,
+} IrxColumnType;
+
+/* ------------------------------------------------------------------ */
+/* Opaque handle types                                                  */
+/* ------------------------------------------------------------------ */
+typedef struct IrxRbSchema_       IrxRbSchema;
+typedef struct IrxRbBuilder_      IrxRbBuilder;
+typedef struct IrxRbBatch_        IrxRbBatch;
+typedef struct IrxRbStreamWriter_ IrxRbStreamWriter;
+typedef struct IrxRbStreamReader_ IrxRbStreamReader;
+
+/* ------------------------------------------------------------------ */
+/* Error reporting                                                      */
+/* ------------------------------------------------------------------ */
+
+/** Return the last error message for the calling thread (never NULL). */
+const char *irx_record_batch_errmsg(void);
+
+/* ------------------------------------------------------------------ */
+/* Schema                                                               */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Create an empty schema. Caller must call irx_rb_schema_release() when done.
+ * @param[out] out  receives the new schema handle.
+ */
+int irx_rb_schema_create(IrxRbSchema **out);
+
+/**
+ * Add a named field to the schema.
+ * @param nullable  non-zero = field may contain nulls.
+ */
+int irx_rb_schema_add_field(IrxRbSchema *schema,
+                             const char  *name,
+                             IrxColumnType type,
+                             int           nullable);
+
+/** Return the number of fields in the schema. */
+int irx_rb_schema_num_fields(const IrxRbSchema *schema);
+
+/** Release the schema handle and free resources. */
+void irx_rb_schema_release(IrxRbSchema *schema);
+
+/* ------------------------------------------------------------------ */
+/* Builder (one per batch)                                              */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Create a new builder for the given schema.
+ * The schema must outlive the builder.
+ */
+int irx_rb_builder_create(const IrxRbSchema *schema, IrxRbBuilder **out);
+
+/* Append helpers — col is a zero-based column index. */
+int irx_rb_builder_append_int8   (IrxRbBuilder *b, int col, int8_t   v);
+int irx_rb_builder_append_int16  (IrxRbBuilder *b, int col, int16_t  v);
+int irx_rb_builder_append_int32  (IrxRbBuilder *b, int col, int32_t  v);
+int irx_rb_builder_append_int64  (IrxRbBuilder *b, int col, int64_t  v);
+int irx_rb_builder_append_uint8  (IrxRbBuilder *b, int col, uint8_t  v);
+int irx_rb_builder_append_uint16 (IrxRbBuilder *b, int col, uint16_t v);
+int irx_rb_builder_append_uint32 (IrxRbBuilder *b, int col, uint32_t v);
+int irx_rb_builder_append_uint64 (IrxRbBuilder *b, int col, uint64_t v);
+int irx_rb_builder_append_float32(IrxRbBuilder *b, int col, float    v);
+int irx_rb_builder_append_float64(IrxRbBuilder *b, int col, double   v);
+int irx_rb_builder_append_bool   (IrxRbBuilder *b, int col, int      v);
+int irx_rb_builder_append_null   (IrxRbBuilder *b, int col);
+
+/**
+ * Finalise the builder and produce a RecordBatch.
+ * All columns must have the same length; otherwise IRX_ERR_ARROW is returned.
+ * @param[out] out  receives the new batch handle.
+ */
+int irx_rb_builder_finish(IrxRbBuilder *b, IrxRbBatch **out);
+
+/** Release the builder. May be called before or after finish(). */
+void irx_rb_builder_release(IrxRbBuilder *b);
+
+/* ------------------------------------------------------------------ */
+/* RecordBatch inspection                                               */
+/* ------------------------------------------------------------------ */
+
+/** Number of rows in the batch. */
+int64_t irx_rb_batch_num_rows(const IrxRbBatch *batch);
+
+/** Number of columns. */
+int irx_rb_batch_num_columns(const IrxRbBatch *batch);
+
+/**
+ * Read a single value from a typed column by row index.
+ * Returns IRX_ERR_OOB if row >= num_rows or col >= num_columns.
+ * Returns IRX_ERR_TYPE if the column type does not match the accessor.
+ */
+int irx_rb_batch_get_int8   (const IrxRbBatch *b, int col, int64_t row, int8_t   *out);
+int irx_rb_batch_get_int16  (const IrxRbBatch *b, int col, int64_t row, int16_t  *out);
+int irx_rb_batch_get_int32  (const IrxRbBatch *b, int col, int64_t row, int32_t  *out);
+int irx_rb_batch_get_int64  (const IrxRbBatch *b, int col, int64_t row, int64_t  *out);
+int irx_rb_batch_get_uint8  (const IrxRbBatch *b, int col, int64_t row, uint8_t  *out);
+int irx_rb_batch_get_uint16 (const IrxRbBatch *b, int col, int64_t row, uint16_t *out);
+int irx_rb_batch_get_uint32 (const IrxRbBatch *b, int col, int64_t row, uint32_t *out);
+int irx_rb_batch_get_uint64 (const IrxRbBatch *b, int col, int64_t row, uint64_t *out);
+int irx_rb_batch_get_float32(const IrxRbBatch *b, int col, int64_t row, float    *out);
+int irx_rb_batch_get_float64(const IrxRbBatch *b, int col, int64_t row, double   *out);
+int irx_rb_batch_get_bool   (const IrxRbBatch *b, int col, int64_t row, int      *out);
+
+/** True if the value at (col, row) is null. */
+int irx_rb_batch_is_null(const IrxRbBatch *b, int col, int64_t row, int *out);
+
+/**
+ * Zero-copy read-only pointer to the raw value buffer of a fixed-width column.
+ * The pointer is valid until irx_rb_batch_release() is called.
+ * @param[out] buf   set to the start of the value buffer.
+ * @param[out] len   number of elements (== num_rows for fixed-width types).
+ */
+int irx_rb_batch_value_buffer(const IrxRbBatch *b, int col,
+                               const void **buf, int64_t *len);
+
+/** Release the batch and free Arrow resources. */
+void irx_rb_batch_release(IrxRbBatch *batch);
+
+/* ------------------------------------------------------------------ */
+/* Stream writer                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Open an Arrow IPC stream writer to a file path.
+ * Creates or truncates the file.
+ */
+int irx_rb_stream_writer_open_file(const IrxRbSchema   *schema,
+                                    const char          *path,
+                                    IrxRbStreamWriter  **out);
+
+/**
+ * Open an Arrow IPC stream writer to a growable in-memory buffer.
+ * Retrieve the finished bytes with irx_rb_stream_writer_buffer_data() after
+ * close.
+ */
+int irx_rb_stream_writer_open_buffer(const IrxRbSchema   *schema,
+                                      IrxRbStreamWriter  **out);
+
+/** Write one RecordBatch to the stream. */
+int irx_rb_stream_writer_write_batch(IrxRbStreamWriter *w,
+                                      const IrxRbBatch  *batch);
+
+/**
+ * Finalise and close the stream.  Must be called before reading back a
+ * buffer-based writer's bytes.
+ */
+int irx_rb_stream_writer_close(IrxRbStreamWriter *w);
+
+/**
+ * For buffer-based writers only: return a pointer to the serialised IPC bytes
+ * and their length.  Valid only after irx_rb_stream_writer_close().
+ * The pointer is owned by the writer and freed by irx_rb_stream_writer_release().
+ */
+int irx_rb_stream_writer_buffer_data(const IrxRbStreamWriter *w,
+                                      const uint8_t **data,
+                                      int64_t        *size);
+
+/** Release the writer. Implicitly closes if not already closed. */
+void irx_rb_stream_writer_release(IrxRbStreamWriter *w);
+
+/* ------------------------------------------------------------------ */
+/* Stream reader                                                        */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Open an Arrow IPC stream reader from a file.
+ * The schema embedded in the stream is used; the caller does not need to
+ * supply one.
+ */
+int irx_rb_stream_reader_open_file(const char         *path,
+                                    IrxRbStreamReader **out);
+
+/**
+ * Open an Arrow IPC stream reader from a byte buffer.
+ * The buffer must remain valid for the lifetime of the reader.
+ */
+int irx_rb_stream_reader_open_buffer(const uint8_t      *data,
+                                      int64_t             size,
+                                      IrxRbStreamReader **out);
+
+/**
+ * Read the next RecordBatch from the stream.
+ * Returns IRX_OK and sets *batch on success.
+ * Returns IRX_EOF (1) when the stream is exhausted (*batch is set to NULL).
+ * Returns a negative IRX_ERR_* on error.
+ */
+int irx_rb_stream_reader_next_batch(IrxRbStreamReader *r,
+                                     IrxRbBatch       **batch);
+
+/**
+ * Return the schema advertised by the stream (do NOT release this pointer;
+ * it is owned by the reader).
+ */
+const IrxRbSchema *irx_rb_stream_reader_schema(const IrxRbStreamReader *r);
+
+/** Close and release the reader. */
+void irx_rb_stream_reader_close(IrxRbStreamReader *r);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif

--- a/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.h
+++ b/packages/irx/src/irx/builder/runtime/arrow/native/irx_record_batch.h
@@ -246,7 +246,8 @@ int irx_rb_stream_reader_open_file(const char         *path,
 
 /**
  * Open an Arrow IPC stream reader from a byte buffer.
- * The buffer must remain valid for the lifetime of the reader.
+ * The bytes are copied into an Arrow-owned buffer, so the caller's buffer
+ * does not need to outlive the reader.
  */
 int irx_rb_stream_reader_open_buffer(const uint8_t      *data,
                                       int64_t             size,

--- a/packages/irx/src/irx/builder/runtime/record_batch.py
+++ b/packages/irx/src/irx/builder/runtime/record_batch.py
@@ -1,0 +1,185 @@
+"""
+packages/irx/src/irx/builder/runtime/record_batch.py
+
+Runtime-feature descriptor for RecordBatch streaming via the Arrow C++ bridge.
+
+This module is discovered by the IRx runtime registry and registers the
+`record_batch` feature so that compiled Arx programs (and IRx-level externs)
+can call the irx_rb_* family of functions.
+
+Usage from an IRx extern declaration (Python side):
+
+    import astx
+    proto = astx.FunctionPrototype(
+        name="irx_rb_schema_create",
+        args=astx.Arguments(),
+        return_type=astx.Int32(),
+        is_extern=True,
+        runtime_feature="record_batch",
+    )
+
+The feature guarantees:
+  * The irx_record_batch.cpp native source is compiled and linked.
+  * Arrow C++ headers are available on the include path (via
+    arx-arrowcpp-sources).
+  * libarrow is linked (requires a system Arrow installation or the one
+    bundled by arx-arrowcpp-sources).
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+
+from pathlib import Path
+from typing import Optional, Sequence
+
+from irx.typecheck import typechecked
+
+# ---------------------------------------------------------------------------
+# Public symbol table
+# ---------------------------------------------------------------------------
+# Every C-level symbol exposed by irx_record_batch.h must appear here so that
+# the IRx lowering layer can route externs through the registry rather than
+# emitting ad-hoc declarations.
+
+RECORD_BATCH_SYMBOLS: frozenset[str] = frozenset(
+    [
+        # Error reporting
+        "irx_record_batch_errmsg",
+        # Schema
+        "irx_rb_schema_create",
+        "irx_rb_schema_add_field",
+        "irx_rb_schema_num_fields",
+        "irx_rb_schema_release",
+        # Builder
+        "irx_rb_builder_create",
+        "irx_rb_builder_append_int8",
+        "irx_rb_builder_append_int16",
+        "irx_rb_builder_append_int32",
+        "irx_rb_builder_append_int64",
+        "irx_rb_builder_append_uint8",
+        "irx_rb_builder_append_uint16",
+        "irx_rb_builder_append_uint32",
+        "irx_rb_builder_append_uint64",
+        "irx_rb_builder_append_float32",
+        "irx_rb_builder_append_float64",
+        "irx_rb_builder_append_bool",
+        "irx_rb_builder_append_null",
+        "irx_rb_builder_finish",
+        "irx_rb_builder_release",
+        # RecordBatch inspection
+        "irx_rb_batch_num_rows",
+        "irx_rb_batch_num_columns",
+        "irx_rb_batch_get_int8",
+        "irx_rb_batch_get_int16",
+        "irx_rb_batch_get_int32",
+        "irx_rb_batch_get_int64",
+        "irx_rb_batch_get_uint8",
+        "irx_rb_batch_get_uint16",
+        "irx_rb_batch_get_uint32",
+        "irx_rb_batch_get_uint64",
+        "irx_rb_batch_get_float32",
+        "irx_rb_batch_get_float64",
+        "irx_rb_batch_get_bool",
+        "irx_rb_batch_is_null",
+        "irx_rb_batch_value_buffer",
+        "irx_rb_batch_release",
+        # Stream writer
+        "irx_rb_stream_writer_open_file",
+        "irx_rb_stream_writer_open_buffer",
+        "irx_rb_stream_writer_write_batch",
+        "irx_rb_stream_writer_close",
+        "irx_rb_stream_writer_buffer_data",
+        "irx_rb_stream_writer_release",
+        # Stream reader
+        "irx_rb_stream_reader_open_file",
+        "irx_rb_stream_reader_open_buffer",
+        "irx_rb_stream_reader_next_batch",
+        "irx_rb_stream_reader_schema",
+        "irx_rb_stream_reader_close",
+    ]
+)
+
+
+@typechecked
+def _arrow_native_source_dir() -> Path:
+    """Return the directory that contains irx_record_batch.cpp."""
+    # Installed package: the C++ sources live next to this file inside the
+    # installed package tree (packages/irx/src/irx/builder/runtime/arrow/).
+    try:
+        ref = importlib.resources.files("irx.builder.runtime.arrow")
+        return Path(str(ref))
+    except Exception:
+        # Editable / development install fall-back: resolve relative to this file.
+        return Path(__file__).parent / "arrow"
+
+
+@typechecked
+def _arrowcpp_include_dir() -> Optional[Path]:
+    """
+    Try to locate Arrow C++ headers via the arx-arrowcpp-sources package.
+    Returns None if the package is not installed (headers must then be on the
+    system include path).
+    """
+    try:
+        import arx_arrowcpp_sources  # type: ignore[import]
+
+        return Path(arx_arrowcpp_sources.include_dir())
+    except ModuleNotFoundError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# IRx RuntimeFeature descriptor
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+class RecordBatchFeature:
+    """
+    IRx runtime feature descriptor for ``record_batch``.
+
+    The IRx registry calls ``native_sources()``, ``extra_include_dirs()``,
+    ``link_flags()``, and ``owned_symbols()`` when building a compilation unit
+    that activates this feature.
+    """
+
+    name: str = "record_batch"
+
+    # The feature depends on the `array` feature (which owns the Arrow C++
+    # build infrastructure and libarrow link flags).  Declaring this here lets
+    # the registry automatically activate `array` whenever `record_batch` is
+    # requested, avoiding duplicate link flags.
+    depends_on: Sequence[str] = ("array",)
+
+    def native_sources(self) -> list[Path]:
+        """C++ source files to compile and link for this feature."""
+        src_dir = _arrow_native_source_dir()
+        return [src_dir / "irx_record_batch.cpp"]
+
+    def extra_include_dirs(self) -> list[Path]:
+        """Additional include directories (Arrow C++ headers)."""
+        dirs: list[Path] = []
+        arrow_inc = _arrowcpp_include_dir()
+        if arrow_inc is not None:
+            dirs.append(arrow_inc)
+        return dirs
+
+    def link_flags(self) -> list[str]:
+        """
+        Extra linker flags.  Arrow is linked via the `array` feature; we only
+        add the IPC component here (arrow_ipc is header-only in Arrow ≥ 12 but
+        was a separate shared lib in earlier versions).
+        """
+        return []  # arrow_ipc is covered by -larrow in the `array` feature
+
+    def owned_symbols(self) -> frozenset[str]:
+        """
+        Return the set of C symbols owned by this feature.  The registry uses
+        this to route extern declarations without ad-hoc hard-coding.
+        """
+        return RECORD_BATCH_SYMBOLS
+
+
+# Singleton instance that the registry imports.
+feature = RecordBatchFeature()

--- a/packages/irx/src/irx/builder/runtime/record_batch.py
+++ b/packages/irx/src/irx/builder/runtime/record_batch.py
@@ -3,183 +3,293 @@ packages/irx/src/irx/builder/runtime/record_batch.py
 
 Runtime-feature descriptor for RecordBatch streaming via the Arrow C++ bridge.
 
-This module is discovered by the IRx runtime registry and registers the
-`record_batch` feature so that compiled Arx programs (and IRx-level externs)
-can call the irx_rb_* family of functions.
-
-Usage from an IRx extern declaration (Python side):
-
-    import astx
-    proto = astx.FunctionPrototype(
-        name="irx_rb_schema_create",
-        args=astx.Arguments(),
-        return_type=astx.Int32(),
-        is_extern=True,
-        runtime_feature="record_batch",
-    )
+This module registers the ``record_batch`` feature with the IRx runtime
+registry so that compiled Arx programs (and IRx-level externs) can call the
+``irx_rb_*`` family of functions declared in ``irx_record_batch.h``.
 
 The feature guarantees:
-  * The irx_record_batch.cpp native source is compiled and linked.
+  * The ``irx_record_batch.cpp`` native source is compiled and linked.
   * Arrow C++ headers are available on the include path (via
-    arx-arrowcpp-sources).
-  * libarrow is linked (requires a system Arrow installation or the one
-    bundled by arx-arrowcpp-sources).
+    arx-arrowcpp-sources / pyarrow).
+  * libarrow is linked.
+
+``record_batch`` depends on the ``array`` feature, which owns the shared Arrow
+C++ build infrastructure; the registry activates ``array`` transitively.
+
+In addition to the LLVM-codegen feature descriptor, this module exposes
+``build_record_batch_shared_library`` which compiles the C++ runtime into a
+standalone shared library for the ctypes-based Python API in
+``irx.record_batch`` (and its tests).
 """
 
 from __future__ import annotations
 
-import importlib.resources
+import subprocess
+import sys
 
+from dataclasses import replace
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Callable
 
+from llvmlite import ir
+
+from irx.builder.runtime.arrowcpp import (
+    arrowcpp_compile_flags,
+    arrowcpp_include_dirs,
+    arrowcpp_linker_flags,
+    arrowcpp_runtime_metadata,
+)
+from irx.builder.runtime.features import (
+    ExternalSymbolSpec,
+    NativeArtifact,
+    RuntimeFeature,
+    declare_external_function,
+)
+from irx.builder.runtime.linking import compile_native_artifacts
 from irx.typecheck import typechecked
 
 # ---------------------------------------------------------------------------
-# Public symbol table
-# ---------------------------------------------------------------------------
-# Every C-level symbol exposed by irx_record_batch.h must appear here so that
-# the IRx lowering layer can route externs through the registry rather than
-# emitting ad-hoc declarations.
-
-RECORD_BATCH_SYMBOLS: frozenset[str] = frozenset(
-    [
-        # Error reporting
-        "irx_record_batch_errmsg",
-        # Schema
-        "irx_rb_schema_create",
-        "irx_rb_schema_add_field",
-        "irx_rb_schema_num_fields",
-        "irx_rb_schema_release",
-        # Builder
-        "irx_rb_builder_create",
-        "irx_rb_builder_append_int8",
-        "irx_rb_builder_append_int16",
-        "irx_rb_builder_append_int32",
-        "irx_rb_builder_append_int64",
-        "irx_rb_builder_append_uint8",
-        "irx_rb_builder_append_uint16",
-        "irx_rb_builder_append_uint32",
-        "irx_rb_builder_append_uint64",
-        "irx_rb_builder_append_float32",
-        "irx_rb_builder_append_float64",
-        "irx_rb_builder_append_bool",
-        "irx_rb_builder_append_null",
-        "irx_rb_builder_finish",
-        "irx_rb_builder_release",
-        # RecordBatch inspection
-        "irx_rb_batch_num_rows",
-        "irx_rb_batch_num_columns",
-        "irx_rb_batch_get_int8",
-        "irx_rb_batch_get_int16",
-        "irx_rb_batch_get_int32",
-        "irx_rb_batch_get_int64",
-        "irx_rb_batch_get_uint8",
-        "irx_rb_batch_get_uint16",
-        "irx_rb_batch_get_uint32",
-        "irx_rb_batch_get_uint64",
-        "irx_rb_batch_get_float32",
-        "irx_rb_batch_get_float64",
-        "irx_rb_batch_get_bool",
-        "irx_rb_batch_is_null",
-        "irx_rb_batch_value_buffer",
-        "irx_rb_batch_release",
-        # Stream writer
-        "irx_rb_stream_writer_open_file",
-        "irx_rb_stream_writer_open_buffer",
-        "irx_rb_stream_writer_write_batch",
-        "irx_rb_stream_writer_close",
-        "irx_rb_stream_writer_buffer_data",
-        "irx_rb_stream_writer_release",
-        # Stream reader
-        "irx_rb_stream_reader_open_file",
-        "irx_rb_stream_reader_open_buffer",
-        "irx_rb_stream_reader_next_batch",
-        "irx_rb_stream_reader_schema",
-        "irx_rb_stream_reader_close",
-    ]
-)
-
-
-@typechecked
-def _arrow_native_source_dir() -> Path:
-    """Return the directory that contains irx_record_batch.cpp."""
-    # Installed package: the C++ sources live next to this file inside the
-    # installed package tree (packages/irx/src/irx/builder/runtime/arrow/).
-    try:
-        ref = importlib.resources.files("irx.builder.runtime.arrow")
-        return Path(str(ref))
-    except Exception:
-        # Editable / development install fall-back: resolve relative to this file.
-        return Path(__file__).parent / "arrow"
-
-
-@typechecked
-def _arrowcpp_include_dir() -> Optional[Path]:
-    """
-    Try to locate Arrow C++ headers via the arx-arrowcpp-sources package.
-    Returns None if the package is not installed (headers must then be on the
-    system include path).
-    """
-    try:
-        import arx_arrowcpp_sources  # type: ignore[import]
-
-        return Path(arx_arrowcpp_sources.include_dir())
-    except ModuleNotFoundError:
-        return None
-
-
-# ---------------------------------------------------------------------------
-# IRx RuntimeFeature descriptor
+# Native source location
 # ---------------------------------------------------------------------------
 
 
 @typechecked
-class RecordBatchFeature:
+def _native_source_dir() -> Path:
+    """Return the directory that contains ``irx_record_batch.cpp``."""
+    return (Path(__file__).resolve().parent / "arrow" / "native").resolve()
+
+
+@typechecked
+def _native_source() -> Path:
+    """Return the path to ``irx_record_batch.cpp``."""
+    return _native_source_dir() / "irx_record_batch.cpp"
+
+
+# ---------------------------------------------------------------------------
+# LLVM symbol signature table
+# ---------------------------------------------------------------------------
+# Each entry maps a C symbol to (return type code, [argument type codes]).
+# Type codes are resolved against ``visitor._llvm`` at declaration time:
+#   p   -> opaque pointer (handle, handle**, char*, void**, uint8_t* ...)
+#   i8/i16/i32/i64 -> integer of that width (enums and `int` use i32)
+#   f32/f64        -> float / double
+#   v              -> void
+# The opaque-pointer type covers every pointer (handles, out-params, byte
+# buffers); IRx never inspects the C structs, so this is sufficient and matches
+# how the ``array`` feature declares its symbols.
+
+_SIGNATURES: dict[str, tuple[str, tuple[str, ...]]] = {
+    # Error reporting
+    "irx_record_batch_errmsg": ("p", ()),
+    # Schema
+    "irx_rb_schema_create": ("i32", ("p",)),
+    "irx_rb_schema_add_field": ("i32", ("p", "p", "i32", "i32")),
+    "irx_rb_schema_num_fields": ("i32", ("p",)),
+    "irx_rb_schema_release": ("v", ("p",)),
+    # Builder
+    "irx_rb_builder_create": ("i32", ("p", "p")),
+    "irx_rb_builder_append_int8": ("i32", ("p", "i32", "i8")),
+    "irx_rb_builder_append_int16": ("i32", ("p", "i32", "i16")),
+    "irx_rb_builder_append_int32": ("i32", ("p", "i32", "i32")),
+    "irx_rb_builder_append_int64": ("i32", ("p", "i32", "i64")),
+    "irx_rb_builder_append_uint8": ("i32", ("p", "i32", "i8")),
+    "irx_rb_builder_append_uint16": ("i32", ("p", "i32", "i16")),
+    "irx_rb_builder_append_uint32": ("i32", ("p", "i32", "i32")),
+    "irx_rb_builder_append_uint64": ("i32", ("p", "i32", "i64")),
+    "irx_rb_builder_append_float32": ("i32", ("p", "i32", "f32")),
+    "irx_rb_builder_append_float64": ("i32", ("p", "i32", "f64")),
+    "irx_rb_builder_append_bool": ("i32", ("p", "i32", "i32")),
+    "irx_rb_builder_append_null": ("i32", ("p", "i32")),
+    "irx_rb_builder_finish": ("i32", ("p", "p")),
+    "irx_rb_builder_release": ("v", ("p",)),
+    # RecordBatch inspection
+    "irx_rb_batch_num_rows": ("i64", ("p",)),
+    "irx_rb_batch_num_columns": ("i32", ("p",)),
+    "irx_rb_batch_get_int8": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_int16": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_int32": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_int64": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_uint8": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_uint16": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_uint32": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_uint64": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_float32": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_float64": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_get_bool": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_is_null": ("i32", ("p", "i32", "i64", "p")),
+    "irx_rb_batch_value_buffer": ("i32", ("p", "i32", "p", "p")),
+    "irx_rb_batch_release": ("v", ("p",)),
+    # Stream writer
+    "irx_rb_stream_writer_open_file": ("i32", ("p", "p", "p")),
+    "irx_rb_stream_writer_open_buffer": ("i32", ("p", "p")),
+    "irx_rb_stream_writer_write_batch": ("i32", ("p", "p")),
+    "irx_rb_stream_writer_close": ("i32", ("p",)),
+    "irx_rb_stream_writer_buffer_data": ("i32", ("p", "p", "p")),
+    "irx_rb_stream_writer_release": ("v", ("p",)),
+    # Stream reader
+    "irx_rb_stream_reader_open_file": ("i32", ("p", "p")),
+    "irx_rb_stream_reader_open_buffer": ("i32", ("p", "i64", "p")),
+    "irx_rb_stream_reader_next_batch": ("i32", ("p", "p")),
+    "irx_rb_stream_reader_schema": ("p", ("p",)),
+    "irx_rb_stream_reader_close": ("v", ("p",)),
+}
+
+RECORD_BATCH_SYMBOLS: frozenset[str] = frozenset(_SIGNATURES)
+
+
+@typechecked
+def _resolve_type(visitor: object, code: str) -> ir.Type:
+    """Map a signature type code to an LLVM type from the visitor's helper."""
+    llvm = visitor._llvm  # type: ignore[attr-defined]
+    if code == "p":
+        return llvm.OPAQUE_POINTER_TYPE
+    if code == "v":
+        return llvm.VOID_TYPE
+    return {
+        "i8": llvm.INT8_TYPE,
+        "i16": llvm.INT16_TYPE,
+        "i32": llvm.INT32_TYPE,
+        "i64": llvm.INT64_TYPE,
+        "f32": llvm.FLOAT_TYPE,
+        "f64": llvm.DOUBLE_TYPE,
+    }[code]
+
+
+@typechecked
+def _make_declarer(
+    name: str, ret_code: str, arg_codes: tuple[str, ...]
+) -> Callable[[object], ir.Function]:
+    """Build a declaration factory for one C symbol."""
+
+    def declare(visitor: object) -> ir.Function:
+        fn_type = ir.FunctionType(
+            _resolve_type(visitor, ret_code),
+            [_resolve_type(visitor, code) for code in arg_codes],
+        )
+        return declare_external_function(
+            visitor._llvm.module,  # type: ignore[attr-defined]
+            name,
+            fn_type,
+        )
+
+    return declare
+
+
+# ---------------------------------------------------------------------------
+# Runtime feature builder
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+def build_record_batch_runtime_feature() -> RuntimeFeature:
     """
-    IRx runtime feature descriptor for ``record_batch``.
-
-    The IRx registry calls ``native_sources()``, ``extra_include_dirs()``,
-    ``link_flags()``, and ``owned_symbols()`` when building a compilation unit
-    that activates this feature.
+    title: Build the RecordBatch streaming runtime feature specification.
+    returns:
+      type: RuntimeFeature
     """
+    native_dir = _native_source_dir()
+    compile_flags = arrowcpp_compile_flags()
+    include_dirs = (native_dir, *arrowcpp_include_dirs())
 
-    name: str = "record_batch"
+    artifacts = (
+        NativeArtifact(
+            kind="cxx_source",
+            path=_native_source(),
+            include_dirs=include_dirs,
+            compile_flags=compile_flags,
+        ),
+    )
 
-    # The feature depends on the `array` feature (which owns the Arrow C++
-    # build infrastructure and libarrow link flags).  Declaring this here lets
-    # the registry automatically activate `array` whenever `record_batch` is
-    # requested, avoiding duplicate link flags.
-    depends_on: Sequence[str] = ("array",)
+    symbols = {
+        name: ExternalSymbolSpec(name, _make_declarer(name, ret, args))
+        for name, (ret, args) in _SIGNATURES.items()
+    }
 
-    def native_sources(self) -> list[Path]:
-        """C++ source files to compile and link for this feature."""
-        src_dir = _arrow_native_source_dir()
-        return [src_dir / "irx_record_batch.cpp"]
-
-    def extra_include_dirs(self) -> list[Path]:
-        """Additional include directories (Arrow C++ headers)."""
-        dirs: list[Path] = []
-        arrow_inc = _arrowcpp_include_dir()
-        if arrow_inc is not None:
-            dirs.append(arrow_inc)
-        return dirs
-
-    def link_flags(self) -> list[str]:
-        """
-        Extra linker flags.  Arrow is linked via the `array` feature; we only
-        add the IPC component here (arrow_ipc is header-only in Arrow ≥ 12 but
-        was a separate shared lib in earlier versions).
-        """
-        return []  # arrow_ipc is covered by -larrow in the `array` feature
-
-    def owned_symbols(self) -> frozenset[str]:
-        """
-        Return the set of C symbols owned by this feature.  The registry uses
-        this to route extern declarations without ad-hoc hard-coding.
-        """
-        return RECORD_BATCH_SYMBOLS
+    return RuntimeFeature(
+        name="record_batch",
+        symbols=symbols,
+        artifacts=artifacts,
+        linker_flags=arrowcpp_linker_flags(),
+        metadata={
+            "canonical_name": "record_batch",
+            "depends_on": ("array",),
+            "opaque_handles": {
+                "schema": "IrxRbSchema",
+                "builder": "IrxRbBuilder",
+                "batch": "IrxRbBatch",
+                "stream_writer": "IrxRbStreamWriter",
+                "stream_reader": "IrxRbStreamReader",
+            },
+            **arrowcpp_runtime_metadata(),
+        },
+    )
 
 
-# Singleton instance that the registry imports.
-feature = RecordBatchFeature()
+# ---------------------------------------------------------------------------
+# Standalone shared-library build (for the ctypes API in irx.record_batch)
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+def _shared_library_name() -> str:
+    """Return the platform shared-library filename the ctypes loader expects."""
+    if sys.platform == "darwin":
+        return "libirx_record_batch.dylib"
+    if sys.platform == "win32":
+        return "irx_record_batch.dll"
+    return "libirx_record_batch.so"
+
+
+@typechecked
+def shared_library_path() -> Path:
+    """Return the canonical install location of the ctypes shared library."""
+    arrow_dir = (Path(__file__).resolve().parent / "arrow").resolve()
+    return arrow_dir / _shared_library_name()
+
+
+@typechecked
+def build_record_batch_shared_library(
+    output_path: Path | None = None,
+    build_dir: Path | None = None,
+    cxx_binary: str = "c++",
+) -> Path:
+    """
+    title: Compile irx_record_batch.cpp into a standalone shared library.
+
+    Used by the ctypes-based Python API (``irx.record_batch``) and its test
+    suite, which load the library directly rather than going through LLVM
+    codegen.
+    parameters:
+      output_path:
+        type: Path | None
+      build_dir:
+        type: Path | None
+      cxx_binary:
+        type: str
+    returns:
+      type: Path
+    """
+    output = output_path or shared_library_path()
+    work_dir = build_dir or (_native_source_dir() / "_build")
+    work_dir.mkdir(parents=True, exist_ok=True)
+
+    feature = build_record_batch_runtime_feature()
+    # Shared objects must be position-independent.
+    pic_artifacts = tuple(
+        replace(a, compile_flags=a.compile_flags + ("-fPIC",))
+        for a in feature.artifacts
+    )
+
+    link_inputs = compile_native_artifacts(
+        artifacts=pic_artifacts,
+        build_dir=work_dir,
+        cxx_binary=cxx_binary,
+    )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    command = [cxx_binary, "-shared", "-o", str(output)]
+    command.extend(str(obj) for obj in link_inputs.objects)
+    command.extend(link_inputs.linker_flags)
+    command.extend(feature.linker_flags)
+    subprocess.run(command, check=True)
+    return output

--- a/packages/irx/src/irx/builder/runtime/record_batch.py
+++ b/packages/irx/src/irx/builder/runtime/record_batch.py
@@ -1,25 +1,5 @@
 """
-packages/irx/src/irx/builder/runtime/record_batch.py
-
-Runtime-feature descriptor for RecordBatch streaming via the Arrow C++ bridge.
-
-This module registers the ``record_batch`` feature with the IRx runtime
-registry so that compiled Arx programs (and IRx-level externs) can call the
-``irx_rb_*`` family of functions declared in ``irx_record_batch.h``.
-
-The feature guarantees:
-  * The ``irx_record_batch.cpp`` native source is compiled and linked.
-  * Arrow C++ headers are available on the include path (via
-    arx-arrowcpp-sources / pyarrow).
-  * libarrow is linked.
-
-``record_batch`` depends on the ``array`` feature, which owns the shared Arrow
-C++ build infrastructure; the registry activates ``array`` transitively.
-
-In addition to the LLVM-codegen feature descriptor, this module exposes
-``build_record_batch_shared_library`` which compiles the C++ runtime into a
-standalone shared library for the ctypes-based Python API in
-``irx.record_batch`` (and its tests).
+title: Record batch streaming API.
 """
 
 from __future__ import annotations
@@ -53,13 +33,21 @@ from irx.typecheck import typechecked
 
 @typechecked
 def _native_source_dir() -> Path:
-    """Return the directory that contains ``irx_record_batch.cpp``."""
+    """
+    title: _native_source_dir.
+    returns:
+      type: Path
+    """
     return (Path(__file__).resolve().parent / "arrow" / "native").resolve()
 
 
 @typechecked
 def _native_source() -> Path:
-    """Return the path to ``irx_record_batch.cpp``."""
+    """
+    title: _native_source.
+    returns:
+      type: Path
+    """
     return _native_source_dir() / "irx_record_batch.cpp"
 
 
@@ -135,7 +123,16 @@ RECORD_BATCH_SYMBOLS: frozenset[str] = frozenset(_SIGNATURES)
 
 @typechecked
 def _resolve_type(visitor: object, code: str) -> ir.Type:
-    """Map a signature type code to an LLVM type from the visitor's helper."""
+    """
+    title: _resolve_type.
+    parameters:
+      visitor:
+        type: object
+      code:
+        type: str
+    returns:
+      type: ir.Type
+    """
     llvm = visitor._llvm  # type: ignore[attr-defined]
     if code == "p":
         return llvm.OPAQUE_POINTER_TYPE
@@ -155,9 +152,28 @@ def _resolve_type(visitor: object, code: str) -> ir.Type:
 def _make_declarer(
     name: str, ret_code: str, arg_codes: tuple[str, ...]
 ) -> Callable[[object], ir.Function]:
-    """Build a declaration factory for one C symbol."""
+    """
+    title: _make_declarer.
+    parameters:
+      name:
+        type: str
+      ret_code:
+        type: str
+      arg_codes:
+        type: tuple[str, Ellipsis]
+    returns:
+      type: Callable[[object], ir.Function]
+    """
 
     def declare(visitor: object) -> ir.Function:
+        """
+        title: Declare a native record-batch symbol for the current visitor.
+        parameters:
+          visitor:
+            type: object
+        returns:
+          type: ir.Function
+        """
         fn_type = ir.FunctionType(
             _resolve_type(visitor, ret_code),
             [_resolve_type(visitor, code) for code in arg_codes],
@@ -224,7 +240,11 @@ def build_record_batch_runtime_feature() -> RuntimeFeature:
 
 @typechecked
 def _shared_library_name() -> str:
-    """Return the platform shared-library filename the ctypes loader expects."""
+    """
+    title: _shared_library_name.
+    returns:
+      type: str
+    """
     if sys.platform == "darwin":
         return "libirx_record_batch.dylib"
     if sys.platform == "win32":
@@ -234,7 +254,11 @@ def _shared_library_name() -> str:
 
 @typechecked
 def shared_library_path() -> Path:
-    """Return the canonical install location of the ctypes shared library."""
+    """
+    title: shared_library_path.
+    returns:
+      type: Path
+    """
     arrow_dir = (Path(__file__).resolve().parent / "arrow").resolve()
     return arrow_dir / _shared_library_name()
 
@@ -247,10 +271,10 @@ def build_record_batch_shared_library(
 ) -> Path:
     """
     title: Compile irx_record_batch.cpp into a standalone shared library.
-
-    Used by the ctypes-based Python API (``irx.record_batch``) and its test
-    suite, which load the library directly rather than going through LLVM
-    codegen.
+    summary: >-
+      Used by the ctypes-based Python API (``irx.record_batch``) and its test
+      suite, which load the library directly rather than going through LLVM
+      codegen.
     parameters:
       output_path:
         type: Path | None
@@ -268,7 +292,7 @@ def build_record_batch_shared_library(
     feature = build_record_batch_runtime_feature()
     # Shared objects must be position-independent.
     pic_artifacts = tuple(
-        replace(a, compile_flags=a.compile_flags + ("-fPIC",))
+        replace(a, compile_flags=(*a.compile_flags, "-fPIC"))
         for a in feature.artifacts
     )
 

--- a/packages/irx/src/irx/builder/runtime/record_batch.py
+++ b/packages/irx/src/irx/builder/runtime/record_batch.py
@@ -48,9 +48,7 @@ from irx.builder.runtime.features import (
 from irx.builder.runtime.linking import compile_native_artifacts
 from irx.typecheck import typechecked
 
-# ---------------------------------------------------------------------------
 # Native source location
-# ---------------------------------------------------------------------------
 
 
 @typechecked
@@ -65,9 +63,7 @@ def _native_source() -> Path:
     return _native_source_dir() / "irx_record_batch.cpp"
 
 
-# ---------------------------------------------------------------------------
 # LLVM symbol signature table
-# ---------------------------------------------------------------------------
 # Each entry maps a C symbol to (return type code, [argument type codes]).
 # Type codes are resolved against ``visitor._llvm`` at declaration time:
 #   p   -> opaque pointer (handle, handle**, char*, void**, uint8_t* ...)
@@ -175,9 +171,7 @@ def _make_declarer(
     return declare
 
 
-# ---------------------------------------------------------------------------
 # Runtime feature builder
-# ---------------------------------------------------------------------------
 
 
 @typechecked
@@ -225,9 +219,7 @@ def build_record_batch_runtime_feature() -> RuntimeFeature:
     )
 
 
-# ---------------------------------------------------------------------------
 # Standalone shared-library build (for the ctypes API in irx.record_batch)
-# ---------------------------------------------------------------------------
 
 
 @typechecked

--- a/packages/irx/src/irx/builder/runtime/registry.py
+++ b/packages/irx/src/irx/builder/runtime/registry.py
@@ -21,6 +21,9 @@ from irx.builder.runtime.feature_libc import build_libc_runtime_feature
 from irx.builder.runtime.feature_libm import build_libm_runtime_feature
 from irx.builder.runtime.features import NativeArtifact, RuntimeFeature
 from irx.builder.runtime.list.feature import build_list_runtime_feature
+from irx.builder.runtime.record_batch import (
+    build_record_batch_runtime_feature,
+)
 from irx.builder.runtime.tensor.feature import build_tensor_runtime_feature
 from irx.diagnostics import (
     Diagnostic,
@@ -305,4 +308,5 @@ def get_default_runtime_feature_registry() -> RuntimeFeatureRegistry:
     registry.register(build_dataframe_runtime_feature())
     registry.register(build_tensor_runtime_feature())
     registry.register(build_list_runtime_feature())
+    registry.register(build_record_batch_runtime_feature())
     return registry

--- a/packages/irx/src/irx/record_batch.py
+++ b/packages/irx/src/irx/record_batch.py
@@ -1,0 +1,723 @@
+"""
+packages/irx/src/irx/record_batch.py
+
+High-level Python API for RecordBatch streaming via the Arrow C++ bridge.
+
+This module provides:
+
+* ``RecordBatchSchema``   — build an Arrow schema incrementally.
+* ``RecordBatchBuilder``  — append typed values and produce a batch.
+* ``RecordBatchStreamWriter`` — write batches to a file or in-memory buffer.
+* ``RecordBatchStreamReader`` — iterate batches from a file or buffer.
+
+The classes are thin wrappers around the opaque C handles declared in
+``irx_record_batch.h``.  They are also the canonical Python-side spelling of
+the feature for IRx integration tests and for Arx programs that need to
+round-trip Arrow IPC data via the Python host.
+
+Example — round-trip through a buffer
+--------------------------------------
+::
+
+    from irx.record_batch import (
+        RecordBatchSchema, RecordBatchBuilder,
+        RecordBatchStreamWriter, RecordBatchStreamReader,
+        IrxColumnType,
+    )
+
+    schema = RecordBatchSchema()
+    schema.add_field("id",    IrxColumnType.INT32,   nullable=False)
+    schema.add_field("value", IrxColumnType.FLOAT64, nullable=True)
+
+    writer = RecordBatchStreamWriter.open_buffer(schema)
+
+    builder = RecordBatchBuilder(schema)
+    for i in range(5):
+        builder.append_int32(0, i)
+        builder.append_float64(1, i * 1.5)
+    batch = builder.finish()
+    writer.write_batch(batch)
+    batch.release()
+    builder.release()
+
+    writer.close()
+    data = writer.buffer_data()
+    writer.release()
+
+    reader = RecordBatchStreamReader.open_buffer(data)
+    while (rb := reader.next_batch()) is not None:
+        print(rb.num_rows(), rb.num_columns())
+        for row in range(rb.num_rows()):
+            print(rb.get_int32(0, row), rb.get_float64(1, row))
+        rb.release()
+    reader.close()
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import sys
+
+from enum import IntEnum
+from pathlib import Path
+from typing import Optional
+
+from irx.typecheck import typechecked
+
+# ---------------------------------------------------------------------------
+# Load the native shared library
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+def _load_native_lib() -> ctypes.CDLL:
+    """
+    Locate and load the IRx Arrow native library.
+
+    During development the library is compiled by the IRx build system and
+    placed under the runtime/arrow/ directory.  In an installed package it will
+    be in the platform lib/ directory next to the Python package.
+    """
+    candidates = [
+        # Development build (in-tree)
+        Path(__file__).parent
+        / "builder"
+        / "runtime"
+        / "arrow"
+        / "libirx_record_batch.so",
+        Path(__file__).parent
+        / "builder"
+        / "runtime"
+        / "arrow"
+        / "libirx_record_batch.dylib",
+        Path(__file__).parent
+        / "builder"
+        / "runtime"
+        / "arrow"
+        / "irx_record_batch.dll",
+        # Installed package
+        Path(sys.prefix) / "lib" / "libirx_record_batch.so",
+        Path(sys.prefix) / "lib" / "libirx_record_batch.dylib",
+    ]
+    for p in candidates:
+        if p.exists():
+            return ctypes.CDLL(str(p))
+
+    # Fall back to ldconfig / PATH search
+    name = ctypes.util.find_library("irx_record_batch")
+    if name:
+        return ctypes.CDLL(name)
+
+    raise RuntimeError(
+        "Could not locate libirx_record_batch.  "
+        "Build the IRx native runtime first: `makim irx.build-native`"
+    )
+
+
+# Lazy-load so importing this module does not fail in environments where the
+# native library has not yet been compiled (e.g. during documentation builds).
+_lib: Optional[ctypes.CDLL] = None
+
+
+@typechecked
+def _get_lib() -> ctypes.CDLL:
+    global _lib
+    if _lib is None:
+        _lib = _load_native_lib()
+        _configure_lib(_lib)
+    return _lib
+
+
+@typechecked
+def _configure_lib(lib: ctypes.CDLL) -> None:
+    """Set argtypes / restype for every exported function."""
+    c = ctypes
+    vp = c.c_void_p
+    pvp = c.POINTER(c.c_void_p)
+    i8 = c.c_int8
+    pi8 = c.POINTER(c.c_int8)
+    i16 = c.c_int16
+    pi16 = c.POINTER(c.c_int16)
+    i32 = c.c_int32
+    pi32 = c.POINTER(c.c_int32)
+    i64 = c.c_int64
+    pi64 = c.POINTER(c.c_int64)
+    u8 = c.c_uint8
+    pu8 = c.POINTER(c.c_uint8)
+    u16 = c.c_uint16
+    pu16 = c.POINTER(c.c_uint16)
+    u32 = c.c_uint32
+    pu32 = c.POINTER(c.c_uint32)
+    u64 = c.c_uint64
+    pu64 = c.POINTER(c.c_uint64)
+    f32 = c.c_float
+    pf32 = c.POINTER(c.c_float)
+    f64 = c.c_double
+    pf64 = c.POINTER(c.c_double)
+    cstr = c.c_char_p
+    pui8 = c.POINTER(c.c_uint8)
+    ppui8 = c.POINTER(pui8)
+
+    def fn(name, restype, *argtypes):
+        f = getattr(lib, name)
+        f.restype = restype
+        f.argtypes = list(argtypes)
+
+    fn("irx_record_batch_errmsg", cstr)
+
+    fn("irx_rb_schema_create", i32, pvp)
+    fn("irx_rb_schema_add_field", i32, vp, cstr, i32, i32)
+    fn("irx_rb_schema_num_fields", i32, vp)
+    fn("irx_rb_schema_release", None, vp)
+
+    fn("irx_rb_builder_create", i32, vp, pvp)
+    fn("irx_rb_builder_append_int8", i32, vp, i32, i8)
+    fn("irx_rb_builder_append_int16", i32, vp, i32, i16)
+    fn("irx_rb_builder_append_int32", i32, vp, i32, i32)
+    fn("irx_rb_builder_append_int64", i32, vp, i32, i64)
+    fn("irx_rb_builder_append_uint8", i32, vp, i32, u8)
+    fn("irx_rb_builder_append_uint16", i32, vp, i32, u16)
+    fn("irx_rb_builder_append_uint32", i32, vp, i32, u32)
+    fn("irx_rb_builder_append_uint64", i32, vp, i32, u64)
+    fn("irx_rb_builder_append_float32", i32, vp, i32, f32)
+    fn("irx_rb_builder_append_float64", i32, vp, i32, f64)
+    fn("irx_rb_builder_append_bool", i32, vp, i32, i32)
+    fn("irx_rb_builder_append_null", i32, vp, i32)
+    fn("irx_rb_builder_finish", i32, vp, pvp)
+    fn("irx_rb_builder_release", None, vp)
+
+    fn("irx_rb_batch_num_rows", i64, vp)
+    fn("irx_rb_batch_num_columns", i32, vp)
+    fn("irx_rb_batch_get_int8", i32, vp, i32, i64, pi8)
+    fn("irx_rb_batch_get_int16", i32, vp, i32, i64, pi16)
+    fn("irx_rb_batch_get_int32", i32, vp, i32, i64, pi32)
+    fn("irx_rb_batch_get_int64", i32, vp, i32, i64, pi64)
+    fn("irx_rb_batch_get_uint8", i32, vp, i32, i64, pu8)
+    fn("irx_rb_batch_get_uint16", i32, vp, i32, i64, pu16)
+    fn("irx_rb_batch_get_uint32", i32, vp, i32, i64, pu32)
+    fn("irx_rb_batch_get_uint64", i32, vp, i32, i64, pu64)
+    fn("irx_rb_batch_get_float32", i32, vp, i32, i64, pf32)
+    fn("irx_rb_batch_get_float64", i32, vp, i32, i64, pf64)
+    fn("irx_rb_batch_get_bool", i32, vp, i32, i64, pi32)
+    fn("irx_rb_batch_is_null", i32, vp, i32, i64, pi32)
+    fn("irx_rb_batch_value_buffer", i32, vp, i32, ppui8, pi64)
+    fn("irx_rb_batch_release", None, vp)
+
+    fn("irx_rb_stream_writer_open_file", i32, vp, cstr, pvp)
+    fn("irx_rb_stream_writer_open_buffer", i32, vp, pvp)
+    fn("irx_rb_stream_writer_write_batch", i32, vp, vp)
+    fn("irx_rb_stream_writer_close", i32, vp)
+    fn("irx_rb_stream_writer_buffer_data", i32, vp, ppui8, pi64)
+    fn("irx_rb_stream_writer_release", None, vp)
+
+    fn("irx_rb_stream_reader_open_file", i32, cstr, pvp)
+    fn("irx_rb_stream_reader_open_buffer", i32, pui8, i64, pvp)
+    fn("irx_rb_stream_reader_next_batch", i32, vp, pvp)
+    fn("irx_rb_stream_reader_schema", vp, vp)
+    fn("irx_rb_stream_reader_close", None, vp)
+
+
+# ---------------------------------------------------------------------------
+# Error helpers
+# ---------------------------------------------------------------------------
+
+IRX_OK = 0
+IRX_EOF = 1
+
+
+@typechecked
+def _check(rc: int, lib: ctypes.CDLL) -> None:
+    if rc < 0:
+        msg = lib.irx_record_batch_errmsg()
+        raise RuntimeError(f"IRx RecordBatch error ({rc}): {msg.decode()}")
+
+
+# ---------------------------------------------------------------------------
+# Public enum
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+class IrxColumnType(IntEnum):
+    INT8 = 0
+    INT16 = 1
+    INT32 = 2
+    INT64 = 3
+    UINT8 = 4
+    UINT16 = 5
+    UINT32 = 6
+    UINT64 = 7
+    FLOAT32 = 8
+    FLOAT64 = 9
+    BOOL = 10
+
+
+# ---------------------------------------------------------------------------
+# RecordBatchSchema
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+class RecordBatchSchema:
+    """Incrementally build an Arrow schema for use with RecordBatch streaming."""
+
+    def __init__(self) -> None:
+        lib = _get_lib()
+        handle = ctypes.c_void_p()
+        _check(lib.irx_rb_schema_create(ctypes.byref(handle)), lib)
+        self._handle = handle
+        self._lib = lib
+        self._released = False
+
+    def add_field(
+        self, name: str, col_type: IrxColumnType, nullable: bool = True
+    ) -> "RecordBatchSchema":
+        """Add a named field to the schema. Returns self for chaining."""
+        _check(
+            self._lib.irx_rb_schema_add_field(
+                self._handle,
+                name.encode(),
+                int(col_type),
+                int(nullable),
+            ),
+            self._lib,
+        )
+        return self
+
+    @property
+    def num_fields(self) -> int:
+        return self._lib.irx_rb_schema_num_fields(self._handle)
+
+    def release(self) -> None:
+        if not self._released:
+            self._lib.irx_rb_schema_release(self._handle)
+            self._released = True
+
+    def __del__(self) -> None:
+        self.release()
+
+    def _raw(self) -> ctypes.c_void_p:
+        return self._handle
+
+
+# ---------------------------------------------------------------------------
+# RecordBatchBuilder
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+class RecordBatchBuilder:
+    """Append typed values column-by-column and produce a RecordBatch."""
+
+    def __init__(self, schema: RecordBatchSchema) -> None:
+        lib = _get_lib()
+        handle = ctypes.c_void_p()
+        _check(
+            lib.irx_rb_builder_create(schema._raw(), ctypes.byref(handle)), lib
+        )
+        self._handle = handle
+        self._lib = lib
+        self._released = False
+
+    # --- typed appends ---
+
+    def append_int8(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_int8(
+                self._handle, col, ctypes.c_int8(v)
+            ),
+            self._lib,
+        )
+
+    def append_int16(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_int16(
+                self._handle, col, ctypes.c_int16(v)
+            ),
+            self._lib,
+        )
+
+    def append_int32(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_int32(
+                self._handle, col, ctypes.c_int32(v)
+            ),
+            self._lib,
+        )
+
+    def append_int64(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_int64(
+                self._handle, col, ctypes.c_int64(v)
+            ),
+            self._lib,
+        )
+
+    def append_uint8(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_uint8(
+                self._handle, col, ctypes.c_uint8(v)
+            ),
+            self._lib,
+        )
+
+    def append_uint16(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_uint16(
+                self._handle, col, ctypes.c_uint16(v)
+            ),
+            self._lib,
+        )
+
+    def append_uint32(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_uint32(
+                self._handle, col, ctypes.c_uint32(v)
+            ),
+            self._lib,
+        )
+
+    def append_uint64(self, col: int, v: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_uint64(
+                self._handle, col, ctypes.c_uint64(v)
+            ),
+            self._lib,
+        )
+
+    def append_float32(self, col: int, v: float) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_float32(
+                self._handle, col, ctypes.c_float(v)
+            ),
+            self._lib,
+        )
+
+    def append_float64(self, col: int, v: float) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_float64(
+                self._handle, col, ctypes.c_double(v)
+            ),
+            self._lib,
+        )
+
+    def append_bool(self, col: int, v: bool) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_bool(
+                self._handle, col, ctypes.c_int32(int(v))
+            ),
+            self._lib,
+        )
+
+    def append_null(self, col: int) -> None:
+        _check(
+            self._lib.irx_rb_builder_append_null(self._handle, col), self._lib
+        )
+
+    def finish(self) -> "RecordBatch":
+        """Finalise and return a RecordBatch handle."""
+        batch_handle = ctypes.c_void_p()
+        _check(
+            self._lib.irx_rb_builder_finish(
+                self._handle, ctypes.byref(batch_handle)
+            ),
+            self._lib,
+        )
+        return RecordBatch(batch_handle, self._lib)
+
+    def release(self) -> None:
+        if not self._released:
+            self._lib.irx_rb_builder_release(self._handle)
+            self._released = True
+
+    def __del__(self) -> None:
+        self.release()
+
+
+# ---------------------------------------------------------------------------
+# RecordBatch (inspection handle)
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+class RecordBatch:
+    """Wraps an irx_rb_batch handle returned by builder.finish() or the reader."""
+
+    def __init__(self, handle: ctypes.c_void_p, lib: ctypes.CDLL) -> None:
+        self._handle = handle
+        self._lib = lib
+        self._released = False
+
+    @property
+    def num_rows(self) -> int:
+        return int(self._lib.irx_rb_batch_num_rows(self._handle))
+
+    @property
+    def num_columns(self) -> int:
+        return int(self._lib.irx_rb_batch_num_columns(self._handle))
+
+    def _scalar_get(self, fn_name, ctype, col, row):
+        out = ctype()
+        _check(
+            getattr(self._lib, fn_name)(
+                self._handle, col, row, ctypes.byref(out)
+            ),
+            self._lib,
+        )
+        return out.value
+
+    def get_int8(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_int8", ctypes.c_int8, col, row
+        )
+
+    def get_int16(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_int16", ctypes.c_int16, col, row
+        )
+
+    def get_int32(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_int32", ctypes.c_int32, col, row
+        )
+
+    def get_int64(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_int64", ctypes.c_int64, col, row
+        )
+
+    def get_uint8(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_uint8", ctypes.c_uint8, col, row
+        )
+
+    def get_uint16(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_uint16", ctypes.c_uint16, col, row
+        )
+
+    def get_uint32(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_uint32", ctypes.c_uint32, col, row
+        )
+
+    def get_uint64(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_uint64", ctypes.c_uint64, col, row
+        )
+
+    def get_float32(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_float32", ctypes.c_float, col, row
+        )
+
+    def get_float64(self, col, row):
+        return self._scalar_get(
+            "irx_rb_batch_get_float64", ctypes.c_double, col, row
+        )
+
+    def get_bool(self, col: int, row: int) -> bool:
+        out = ctypes.c_int32()
+        _check(
+            self._lib.irx_rb_batch_get_bool(
+                self._handle, col, row, ctypes.byref(out)
+            ),
+            self._lib,
+        )
+        return bool(out.value)
+
+    def is_null(self, col: int, row: int) -> bool:
+        out = ctypes.c_int32()
+        _check(
+            self._lib.irx_rb_batch_is_null(
+                self._handle, col, row, ctypes.byref(out)
+            ),
+            self._lib,
+        )
+        return bool(out.value)
+
+    def release(self) -> None:
+        if not self._released:
+            self._lib.irx_rb_batch_release(self._handle)
+            self._released = True
+
+    def __del__(self) -> None:
+        self.release()
+
+
+# ---------------------------------------------------------------------------
+# RecordBatchStreamWriter
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+class RecordBatchStreamWriter:
+    """Write RecordBatches to an Arrow IPC stream (file or in-memory buffer)."""
+
+    def __init__(
+        self,
+        handle: ctypes.c_void_p,
+        lib: ctypes.CDLL,
+        is_buffer: bool = False,
+    ) -> None:
+        self._handle = handle
+        self._lib = lib
+        self._is_buffer = is_buffer
+        self._closed = False
+        self._released = False
+
+    @classmethod
+    def open_file(
+        cls, schema: RecordBatchSchema, path: str | os.PathLike
+    ) -> "RecordBatchStreamWriter":
+        lib = _get_lib()
+        handle = ctypes.c_void_p()
+        _check(
+            lib.irx_rb_stream_writer_open_file(
+                schema._raw(), str(path).encode(), ctypes.byref(handle)
+            ),
+            lib,
+        )
+        return cls(handle, lib, is_buffer=False)
+
+    @classmethod
+    def open_buffer(
+        cls, schema: RecordBatchSchema
+    ) -> "RecordBatchStreamWriter":
+        lib = _get_lib()
+        handle = ctypes.c_void_p()
+        _check(
+            lib.irx_rb_stream_writer_open_buffer(
+                schema._raw(), ctypes.byref(handle)
+            ),
+            lib,
+        )
+        return cls(handle, lib, is_buffer=True)
+
+    def write_batch(self, batch: RecordBatch) -> None:
+        _check(
+            self._lib.irx_rb_stream_writer_write_batch(
+                self._handle, batch._handle
+            ),
+            self._lib,
+        )
+
+    def close(self) -> None:
+        if not self._closed:
+            _check(
+                self._lib.irx_rb_stream_writer_close(self._handle), self._lib
+            )
+            self._closed = True
+
+    def buffer_data(self) -> bytes:
+        """
+        Return the serialised IPC bytes (buffer writers only).
+        Must be called after close().
+        """
+        if not self._is_buffer:
+            raise RuntimeError(
+                "This writer is file-based; buffer_data() is not available."
+            )
+        data_ptr = ctypes.POINTER(ctypes.c_uint8)()
+        size = ctypes.c_int64()
+        _check(
+            self._lib.irx_rb_stream_writer_buffer_data(
+                self._handle,
+                ctypes.byref(data_ptr),
+                ctypes.byref(size),
+            ),
+            self._lib,
+        )
+        return bytes(ctypes.string_at(data_ptr, size.value))
+
+    def release(self) -> None:
+        if not self._released:
+            self._lib.irx_rb_stream_writer_release(self._handle)
+            self._released = True
+
+    def __del__(self) -> None:
+        self.release()
+
+    def __enter__(self) -> "RecordBatchStreamWriter":
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()
+        self.release()
+
+
+# ---------------------------------------------------------------------------
+# RecordBatchStreamReader
+# ---------------------------------------------------------------------------
+
+
+@typechecked
+class RecordBatchStreamReader:
+    """Read RecordBatches from an Arrow IPC stream (file or in-memory buffer)."""
+
+    def __init__(self, handle: ctypes.c_void_p, lib: ctypes.CDLL) -> None:
+        self._handle = handle
+        self._lib = lib
+        self._closed = False
+
+    @classmethod
+    def open_file(cls, path: str | os.PathLike) -> "RecordBatchStreamReader":
+        lib = _get_lib()
+        handle = ctypes.c_void_p()
+        _check(
+            lib.irx_rb_stream_reader_open_file(
+                str(path).encode(), ctypes.byref(handle)
+            ),
+            lib,
+        )
+        return cls(handle, lib)
+
+    @classmethod
+    def open_buffer(cls, data: bytes) -> "RecordBatchStreamReader":
+        lib = _get_lib()
+        handle = ctypes.c_void_p()
+        buf = (ctypes.c_uint8 * len(data)).from_buffer_copy(data)
+        _check(
+            lib.irx_rb_stream_reader_open_buffer(
+                buf, ctypes.c_int64(len(data)), ctypes.byref(handle)
+            ),
+            lib,
+        )
+        return cls(handle, lib)
+
+    def next_batch(self) -> Optional[RecordBatch]:
+        """
+        Return the next RecordBatch or None at end-of-stream.
+        Caller is responsible for calling RecordBatch.release().
+        """
+        batch_handle = ctypes.c_void_p()
+        rc = self._lib.irx_rb_stream_reader_next_batch(
+            self._handle, ctypes.byref(batch_handle)
+        )
+        if rc == IRX_EOF:
+            return None
+        _check(rc, self._lib)
+        return RecordBatch(batch_handle, self._lib)
+
+    def __iter__(self):
+        batch = self.next_batch()
+        while batch is not None:
+            yield batch
+            batch.release()
+            batch = self.next_batch()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._lib.irx_rb_stream_reader_close(self._handle)
+            self._closed = True
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __enter__(self) -> "RecordBatchStreamReader":
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()

--- a/packages/irx/src/irx/record_batch.py
+++ b/packages/irx/src/irx/record_batch.py
@@ -60,9 +60,11 @@ import ctypes.util
 import os
 import sys
 
+from collections.abc import Iterator
 from enum import IntEnum
+from functools import lru_cache
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from irx.typecheck import typechecked
 
@@ -116,18 +118,14 @@ def _load_native_lib() -> ctypes.CDLL:
     )
 
 
-# Lazy-load so importing this module does not fail in environments where the
-# native library has not yet been compiled (e.g. during documentation builds).
-_lib: Optional[ctypes.CDLL] = None
-
-
+# Lazy-load (cached) so importing this module does not fail where the native
+# library has not been compiled yet (e.g. documentation builds).
+@lru_cache(maxsize=1)
 @typechecked
 def _get_lib() -> ctypes.CDLL:
-    global _lib
-    if _lib is None:
-        _lib = _load_native_lib()
-        _configure_lib(_lib)
-    return _lib
+    lib = _load_native_lib()
+    _configure_lib(lib)
+    return lib
 
 
 @typechecked
@@ -160,7 +158,7 @@ def _configure_lib(lib: ctypes.CDLL) -> None:
     pui8 = c.POINTER(c.c_uint8)
     ppui8 = c.POINTER(pui8)
 
-    def fn(name, restype, *argtypes):
+    def fn(name: str, restype: Any, *argtypes: Any) -> None:
         f = getattr(lib, name)
         f.restype = restype
         f.argtypes = list(argtypes)
@@ -261,7 +259,7 @@ class IrxColumnType(IntEnum):
 
 @typechecked
 class RecordBatchSchema:
-    """Incrementally build an Arrow schema for use with RecordBatch streaming."""
+    """Incrementally build an Arrow schema for RecordBatch streaming."""
 
     def __init__(self) -> None:
         lib = _get_lib()
@@ -288,7 +286,7 @@ class RecordBatchSchema:
 
     @property
     def num_fields(self) -> int:
-        return self._lib.irx_rb_schema_num_fields(self._handle)
+        return int(self._lib.irx_rb_schema_num_fields(self._handle))
 
     def release(self) -> None:
         if not self._released:
@@ -443,7 +441,7 @@ class RecordBatchBuilder:
 
 @typechecked
 class RecordBatch:
-    """Wraps an irx_rb_batch handle returned by builder.finish() or the reader."""
+    """Wraps an irx_rb_batch handle from builder.finish() or the reader."""
 
     def __init__(self, handle: ctypes.c_void_p, lib: ctypes.CDLL) -> None:
         self._handle = handle
@@ -458,7 +456,9 @@ class RecordBatch:
     def num_columns(self) -> int:
         return int(self._lib.irx_rb_batch_num_columns(self._handle))
 
-    def _scalar_get(self, fn_name, ctype, col, row):
+    def _scalar_get(
+        self, fn_name: str, ctype: type[Any], col: int, row: int
+    ) -> Any:
         out = ctype()
         _check(
             getattr(self._lib, fn_name)(
@@ -468,54 +468,72 @@ class RecordBatch:
         )
         return out.value
 
-    def get_int8(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_int8", ctypes.c_int8, col, row
+    def get_int8(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get("irx_rb_batch_get_int8", ctypes.c_int8, col, row)
         )
 
-    def get_int16(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_int16", ctypes.c_int16, col, row
+    def get_int16(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get(
+                "irx_rb_batch_get_int16", ctypes.c_int16, col, row
+            )
         )
 
-    def get_int32(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_int32", ctypes.c_int32, col, row
+    def get_int32(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get(
+                "irx_rb_batch_get_int32", ctypes.c_int32, col, row
+            )
         )
 
-    def get_int64(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_int64", ctypes.c_int64, col, row
+    def get_int64(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get(
+                "irx_rb_batch_get_int64", ctypes.c_int64, col, row
+            )
         )
 
-    def get_uint8(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_uint8", ctypes.c_uint8, col, row
+    def get_uint8(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get(
+                "irx_rb_batch_get_uint8", ctypes.c_uint8, col, row
+            )
         )
 
-    def get_uint16(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_uint16", ctypes.c_uint16, col, row
+    def get_uint16(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get(
+                "irx_rb_batch_get_uint16", ctypes.c_uint16, col, row
+            )
         )
 
-    def get_uint32(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_uint32", ctypes.c_uint32, col, row
+    def get_uint32(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get(
+                "irx_rb_batch_get_uint32", ctypes.c_uint32, col, row
+            )
         )
 
-    def get_uint64(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_uint64", ctypes.c_uint64, col, row
+    def get_uint64(self, col: int, row: int) -> int:
+        return int(
+            self._scalar_get(
+                "irx_rb_batch_get_uint64", ctypes.c_uint64, col, row
+            )
         )
 
-    def get_float32(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_float32", ctypes.c_float, col, row
+    def get_float32(self, col: int, row: int) -> float:
+        return float(
+            self._scalar_get(
+                "irx_rb_batch_get_float32", ctypes.c_float, col, row
+            )
         )
 
-    def get_float64(self, col, row):
-        return self._scalar_get(
-            "irx_rb_batch_get_float64", ctypes.c_double, col, row
+    def get_float64(self, col: int, row: int) -> float:
+        return float(
+            self._scalar_get(
+                "irx_rb_batch_get_float64", ctypes.c_double, col, row
+            )
         )
 
     def get_bool(self, col: int, row: int) -> bool:
@@ -554,7 +572,7 @@ class RecordBatch:
 
 @typechecked
 class RecordBatchStreamWriter:
-    """Write RecordBatches to an Arrow IPC stream (file or in-memory buffer)."""
+    """Write RecordBatches to an Arrow IPC stream (file or buffer)."""
 
     def __init__(
         self,
@@ -570,7 +588,7 @@ class RecordBatchStreamWriter:
 
     @classmethod
     def open_file(
-        cls, schema: RecordBatchSchema, path: str | os.PathLike
+        cls, schema: RecordBatchSchema, path: str | os.PathLike[str]
     ) -> "RecordBatchStreamWriter":
         lib = _get_lib()
         handle = ctypes.c_void_p()
@@ -643,7 +661,7 @@ class RecordBatchStreamWriter:
     def __enter__(self) -> "RecordBatchStreamWriter":
         return self
 
-    def __exit__(self, *_) -> None:
+    def __exit__(self, *exc: object) -> None:
         self.close()
         self.release()
 
@@ -655,7 +673,7 @@ class RecordBatchStreamWriter:
 
 @typechecked
 class RecordBatchStreamReader:
-    """Read RecordBatches from an Arrow IPC stream (file or in-memory buffer)."""
+    """Read RecordBatches from an Arrow IPC stream (file or buffer)."""
 
     def __init__(self, handle: ctypes.c_void_p, lib: ctypes.CDLL) -> None:
         self._handle = handle
@@ -663,7 +681,9 @@ class RecordBatchStreamReader:
         self._closed = False
 
     @classmethod
-    def open_file(cls, path: str | os.PathLike) -> "RecordBatchStreamReader":
+    def open_file(
+        cls, path: str | os.PathLike[str]
+    ) -> "RecordBatchStreamReader":
         lib = _get_lib()
         handle = ctypes.c_void_p()
         _check(
@@ -701,7 +721,7 @@ class RecordBatchStreamReader:
         _check(rc, self._lib)
         return RecordBatch(batch_handle, self._lib)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[RecordBatch]:
         batch = self.next_batch()
         while batch is not None:
             yield batch
@@ -719,5 +739,5 @@ class RecordBatchStreamReader:
     def __enter__(self) -> "RecordBatchStreamReader":
         return self
 
-    def __exit__(self, *_) -> None:
+    def __exit__(self, *exc: object) -> None:
         self.close()

--- a/packages/irx/src/irx/record_batch.py
+++ b/packages/irx/src/irx/record_batch.py
@@ -1,56 +1,5 @@
 """
-packages/irx/src/irx/record_batch.py
-
-High-level Python API for RecordBatch streaming via the Arrow C++ bridge.
-
-This module provides:
-
-* ``RecordBatchSchema``   — build an Arrow schema incrementally.
-* ``RecordBatchBuilder``  — append typed values and produce a batch.
-* ``RecordBatchStreamWriter`` — write batches to a file or in-memory buffer.
-* ``RecordBatchStreamReader`` — iterate batches from a file or buffer.
-
-The classes are thin wrappers around the opaque C handles declared in
-``irx_record_batch.h``.  They are also the canonical Python-side spelling of
-the feature for IRx integration tests and for Arx programs that need to
-round-trip Arrow IPC data via the Python host.
-
-Example — round-trip through a buffer
---------------------------------------
-::
-
-    from irx.record_batch import (
-        RecordBatchSchema, RecordBatchBuilder,
-        RecordBatchStreamWriter, RecordBatchStreamReader,
-        IrxColumnType,
-    )
-
-    schema = RecordBatchSchema()
-    schema.add_field("id",    IrxColumnType.INT32,   nullable=False)
-    schema.add_field("value", IrxColumnType.FLOAT64, nullable=True)
-
-    writer = RecordBatchStreamWriter.open_buffer(schema)
-
-    builder = RecordBatchBuilder(schema)
-    for i in range(5):
-        builder.append_int32(0, i)
-        builder.append_float64(1, i * 1.5)
-    batch = builder.finish()
-    writer.write_batch(batch)
-    batch.release()
-    builder.release()
-
-    writer.close()
-    data = writer.buffer_data()
-    writer.release()
-
-    reader = RecordBatchStreamReader.open_buffer(data)
-    while (rb := reader.next_batch()) is not None:
-        print(rb.num_rows(), rb.num_columns())
-        for row in range(rb.num_rows()):
-            print(rb.get_int32(0, row), rb.get_float64(1, row))
-        rb.release()
-    reader.close()
+title: Record batch streaming API.
 """
 
 from __future__ import annotations
@@ -76,11 +25,9 @@ from irx.typecheck import typechecked
 @typechecked
 def _load_native_lib() -> ctypes.CDLL:
     """
-    Locate and load the IRx Arrow native library.
-
-    During development the library is compiled by the IRx build system and
-    placed under the runtime/arrow/ directory.  In an installed package it will
-    be in the platform lib/ directory next to the Python package.
+    title: _load_native_lib.
+    returns:
+      type: ctypes.CDLL
     """
     candidates = [
         # Development build (in-tree)
@@ -123,6 +70,11 @@ def _load_native_lib() -> ctypes.CDLL:
 @lru_cache(maxsize=1)
 @typechecked
 def _get_lib() -> ctypes.CDLL:
+    """
+    title: Return the lazily-loaded record-batch native library.
+    returns:
+      type: ctypes.CDLL
+    """
     lib = _load_native_lib()
     _configure_lib(lib)
     return lib
@@ -130,7 +82,12 @@ def _get_lib() -> ctypes.CDLL:
 
 @typechecked
 def _configure_lib(lib: ctypes.CDLL) -> None:
-    """Set argtypes / restype for every exported function."""
+    """
+    title: _configure_lib.
+    parameters:
+      lib:
+        type: ctypes.CDLL
+    """
     c = ctypes
     vp = c.c_void_p
     pvp = c.POINTER(c.c_void_p)
@@ -159,6 +116,17 @@ def _configure_lib(lib: ctypes.CDLL) -> None:
     ppui8 = c.POINTER(pui8)
 
     def fn(name: str, restype: Any, *argtypes: Any) -> None:
+        """
+        title: Configure ctypes metadata for one exported native function.
+        parameters:
+          name:
+            type: str
+          restype:
+            type: Any
+          argtypes:
+            type: Any
+            variadic: positional
+        """
         f = getattr(lib, name)
         f.restype = restype
         f.argtypes = list(argtypes)
@@ -227,6 +195,14 @@ IRX_EOF = 1
 
 @typechecked
 def _check(rc: int, lib: ctypes.CDLL) -> None:
+    """
+    title: Validate a native record-batch call result code.
+    parameters:
+      rc:
+        type: int
+      lib:
+        type: ctypes.CDLL
+    """
     if rc < 0:
         msg = lib.irx_record_batch_errmsg()
         raise RuntimeError(f"IRx RecordBatch error ({rc}): {msg.decode()}")
@@ -239,6 +215,10 @@ def _check(rc: int, lib: ctypes.CDLL) -> None:
 
 @typechecked
 class IrxColumnType(IntEnum):
+    """
+    title: IrxColumnType.
+    """
+
     INT8 = 0
     INT16 = 1
     INT32 = 2
@@ -259,9 +239,25 @@ class IrxColumnType(IntEnum):
 
 @typechecked
 class RecordBatchSchema:
-    """Incrementally build an Arrow schema for RecordBatch streaming."""
+    """
+    title: RecordBatchSchema.
+    attributes:
+      _handle:
+        type: ctypes.c_void_p
+      _lib:
+        type: ctypes.CDLL
+      _released:
+        type: bool
+    """
+
+    _handle: ctypes.c_void_p
+    _lib: ctypes.CDLL
+    _released: bool
 
     def __init__(self) -> None:
+        """
+        title: Create a new Arrow schema handle.
+        """
         lib = _get_lib()
         handle = ctypes.c_void_p()
         _check(lib.irx_rb_schema_create(ctypes.byref(handle)), lib)
@@ -272,7 +268,18 @@ class RecordBatchSchema:
     def add_field(
         self, name: str, col_type: IrxColumnType, nullable: bool = True
     ) -> "RecordBatchSchema":
-        """Add a named field to the schema. Returns self for chaining."""
+        """
+        title: add_field.
+        parameters:
+          name:
+            type: str
+          col_type:
+            type: IrxColumnType
+          nullable:
+            type: bool
+        returns:
+          type: RecordBatchSchema
+        """
         _check(
             self._lib.irx_rb_schema_add_field(
                 self._handle,
@@ -286,17 +293,33 @@ class RecordBatchSchema:
 
     @property
     def num_fields(self) -> int:
+        """
+        title: Return the number of schema fields.
+        returns:
+          type: int
+        """
         return int(self._lib.irx_rb_schema_num_fields(self._handle))
 
     def release(self) -> None:
+        """
+        title: Release the underlying schema handle.
+        """
         if not self._released:
             self._lib.irx_rb_schema_release(self._handle)
             self._released = True
 
     def __del__(self) -> None:
+        """
+        title: Release the schema when the object is garbage collected.
+        """
         self.release()
 
     def _raw(self) -> ctypes.c_void_p:
+        """
+        title: Return the underlying native handle.
+        returns:
+          type: ctypes.c_void_p
+        """
         return self._handle
 
 
@@ -307,9 +330,28 @@ class RecordBatchSchema:
 
 @typechecked
 class RecordBatchBuilder:
-    """Append typed values column-by-column and produce a RecordBatch."""
+    """
+    title: RecordBatchBuilder.
+    attributes:
+      _handle:
+        type: ctypes.c_void_p
+      _lib:
+        type: ctypes.CDLL
+      _released:
+        type: bool
+    """
+
+    _handle: ctypes.c_void_p
+    _lib: ctypes.CDLL
+    _released: bool
 
     def __init__(self, schema: RecordBatchSchema) -> None:
+        """
+        title: Create a builder for the supplied schema.
+        parameters:
+          schema:
+            type: RecordBatchSchema
+        """
         lib = _get_lib()
         handle = ctypes.c_void_p()
         _check(
@@ -322,6 +364,14 @@ class RecordBatchBuilder:
     # --- typed appends ---
 
     def append_int8(self, col: int, v: int) -> None:
+        """
+        title: Append an 8-bit signed integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_int8(
                 self._handle, col, ctypes.c_int8(v)
@@ -330,6 +380,14 @@ class RecordBatchBuilder:
         )
 
     def append_int16(self, col: int, v: int) -> None:
+        """
+        title: Append a 16-bit signed integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_int16(
                 self._handle, col, ctypes.c_int16(v)
@@ -338,6 +396,14 @@ class RecordBatchBuilder:
         )
 
     def append_int32(self, col: int, v: int) -> None:
+        """
+        title: Append a 32-bit signed integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_int32(
                 self._handle, col, ctypes.c_int32(v)
@@ -346,6 +412,14 @@ class RecordBatchBuilder:
         )
 
     def append_int64(self, col: int, v: int) -> None:
+        """
+        title: Append a 64-bit signed integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_int64(
                 self._handle, col, ctypes.c_int64(v)
@@ -354,6 +428,14 @@ class RecordBatchBuilder:
         )
 
     def append_uint8(self, col: int, v: int) -> None:
+        """
+        title: Append an 8-bit unsigned integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_uint8(
                 self._handle, col, ctypes.c_uint8(v)
@@ -362,6 +444,14 @@ class RecordBatchBuilder:
         )
 
     def append_uint16(self, col: int, v: int) -> None:
+        """
+        title: Append a 16-bit unsigned integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_uint16(
                 self._handle, col, ctypes.c_uint16(v)
@@ -370,6 +460,14 @@ class RecordBatchBuilder:
         )
 
     def append_uint32(self, col: int, v: int) -> None:
+        """
+        title: Append a 32-bit unsigned integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_uint32(
                 self._handle, col, ctypes.c_uint32(v)
@@ -378,6 +476,14 @@ class RecordBatchBuilder:
         )
 
     def append_uint64(self, col: int, v: int) -> None:
+        """
+        title: Append a 64-bit unsigned integer to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_uint64(
                 self._handle, col, ctypes.c_uint64(v)
@@ -386,6 +492,14 @@ class RecordBatchBuilder:
         )
 
     def append_float32(self, col: int, v: float) -> None:
+        """
+        title: Append a 32-bit floating-point value to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: float
+        """
         _check(
             self._lib.irx_rb_builder_append_float32(
                 self._handle, col, ctypes.c_float(v)
@@ -394,6 +508,14 @@ class RecordBatchBuilder:
         )
 
     def append_float64(self, col: int, v: float) -> None:
+        """
+        title: Append a 64-bit floating-point value to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: float
+        """
         _check(
             self._lib.irx_rb_builder_append_float64(
                 self._handle, col, ctypes.c_double(v)
@@ -402,6 +524,14 @@ class RecordBatchBuilder:
         )
 
     def append_bool(self, col: int, v: bool) -> None:
+        """
+        title: Append a boolean value to a column.
+        parameters:
+          col:
+            type: int
+          v:
+            type: bool
+        """
         _check(
             self._lib.irx_rb_builder_append_bool(
                 self._handle, col, ctypes.c_int32(int(v))
@@ -410,12 +540,22 @@ class RecordBatchBuilder:
         )
 
     def append_null(self, col: int) -> None:
+        """
+        title: Append a null value to a column.
+        parameters:
+          col:
+            type: int
+        """
         _check(
             self._lib.irx_rb_builder_append_null(self._handle, col), self._lib
         )
 
     def finish(self) -> "RecordBatch":
-        """Finalise and return a RecordBatch handle."""
+        """
+        title: finish.
+        returns:
+          type: RecordBatch
+        """
         batch_handle = ctypes.c_void_p()
         _check(
             self._lib.irx_rb_builder_finish(
@@ -426,11 +566,17 @@ class RecordBatchBuilder:
         return RecordBatch(batch_handle, self._lib)
 
     def release(self) -> None:
+        """
+        title: Release the underlying builder handle.
+        """
         if not self._released:
             self._lib.irx_rb_builder_release(self._handle)
             self._released = True
 
     def __del__(self) -> None:
+        """
+        title: Release the builder when the object is garbage collected.
+        """
         self.release()
 
 
@@ -441,24 +587,69 @@ class RecordBatchBuilder:
 
 @typechecked
 class RecordBatch:
-    """Wraps an irx_rb_batch handle from builder.finish() or the reader."""
+    """
+    title: RecordBatch.
+    attributes:
+      _handle:
+        type: ctypes.c_void_p
+      _lib:
+        type: ctypes.CDLL
+      _released:
+        type: bool
+    """
+
+    _handle: ctypes.c_void_p
+    _lib: ctypes.CDLL
+    _released: bool
 
     def __init__(self, handle: ctypes.c_void_p, lib: ctypes.CDLL) -> None:
+        """
+        title: Create a wrapper around an existing native batch handle.
+        parameters:
+          handle:
+            type: ctypes.c_void_p
+          lib:
+            type: ctypes.CDLL
+        """
         self._handle = handle
         self._lib = lib
         self._released = False
 
     @property
     def num_rows(self) -> int:
+        """
+        title: Return the number of rows in the batch.
+        returns:
+          type: int
+        """
         return int(self._lib.irx_rb_batch_num_rows(self._handle))
 
     @property
     def num_columns(self) -> int:
+        """
+        title: Return the number of columns in the batch.
+        returns:
+          type: int
+        """
         return int(self._lib.irx_rb_batch_num_columns(self._handle))
 
     def _scalar_get(
         self, fn_name: str, ctype: type[Any], col: int, row: int
     ) -> Any:
+        """
+        title: Read a scalar value from the batch through a native getter.
+        parameters:
+          fn_name:
+            type: str
+          ctype:
+            type: type[Any]
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: Any
+        """
         out = ctype()
         _check(
             getattr(self._lib, fn_name)(
@@ -469,11 +660,31 @@ class RecordBatch:
         return out.value
 
     def get_int8(self, col: int, row: int) -> int:
+        """
+        title: Return an 8-bit signed integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get("irx_rb_batch_get_int8", ctypes.c_int8, col, row)
         )
 
     def get_int16(self, col: int, row: int) -> int:
+        """
+        title: Return a 16-bit signed integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get(
                 "irx_rb_batch_get_int16", ctypes.c_int16, col, row
@@ -481,6 +692,16 @@ class RecordBatch:
         )
 
     def get_int32(self, col: int, row: int) -> int:
+        """
+        title: Return a 32-bit signed integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get(
                 "irx_rb_batch_get_int32", ctypes.c_int32, col, row
@@ -488,6 +709,16 @@ class RecordBatch:
         )
 
     def get_int64(self, col: int, row: int) -> int:
+        """
+        title: Return a 64-bit signed integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get(
                 "irx_rb_batch_get_int64", ctypes.c_int64, col, row
@@ -495,6 +726,16 @@ class RecordBatch:
         )
 
     def get_uint8(self, col: int, row: int) -> int:
+        """
+        title: Return an 8-bit unsigned integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get(
                 "irx_rb_batch_get_uint8", ctypes.c_uint8, col, row
@@ -502,6 +743,16 @@ class RecordBatch:
         )
 
     def get_uint16(self, col: int, row: int) -> int:
+        """
+        title: Return a 16-bit unsigned integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get(
                 "irx_rb_batch_get_uint16", ctypes.c_uint16, col, row
@@ -509,6 +760,16 @@ class RecordBatch:
         )
 
     def get_uint32(self, col: int, row: int) -> int:
+        """
+        title: Return a 32-bit unsigned integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get(
                 "irx_rb_batch_get_uint32", ctypes.c_uint32, col, row
@@ -516,6 +777,16 @@ class RecordBatch:
         )
 
     def get_uint64(self, col: int, row: int) -> int:
+        """
+        title: Return a 64-bit unsigned integer value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: int
+        """
         return int(
             self._scalar_get(
                 "irx_rb_batch_get_uint64", ctypes.c_uint64, col, row
@@ -523,6 +794,16 @@ class RecordBatch:
         )
 
     def get_float32(self, col: int, row: int) -> float:
+        """
+        title: Return a 32-bit floating-point value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: float
+        """
         return float(
             self._scalar_get(
                 "irx_rb_batch_get_float32", ctypes.c_float, col, row
@@ -530,6 +811,16 @@ class RecordBatch:
         )
 
     def get_float64(self, col: int, row: int) -> float:
+        """
+        title: Return a 64-bit floating-point value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: float
+        """
         return float(
             self._scalar_get(
                 "irx_rb_batch_get_float64", ctypes.c_double, col, row
@@ -537,6 +828,16 @@ class RecordBatch:
         )
 
     def get_bool(self, col: int, row: int) -> bool:
+        """
+        title: Return a boolean value from the batch.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: bool
+        """
         out = ctypes.c_int32()
         _check(
             self._lib.irx_rb_batch_get_bool(
@@ -547,6 +848,16 @@ class RecordBatch:
         return bool(out.value)
 
     def is_null(self, col: int, row: int) -> bool:
+        """
+        title: Return whether the value at the supplied location is null.
+        parameters:
+          col:
+            type: int
+          row:
+            type: int
+        returns:
+          type: bool
+        """
         out = ctypes.c_int32()
         _check(
             self._lib.irx_rb_batch_is_null(
@@ -557,11 +868,17 @@ class RecordBatch:
         return bool(out.value)
 
     def release(self) -> None:
+        """
+        title: Release the underlying batch handle.
+        """
         if not self._released:
             self._lib.irx_rb_batch_release(self._handle)
             self._released = True
 
     def __del__(self) -> None:
+        """
+        title: Release the batch when the object is garbage collected.
+        """
         self.release()
 
 
@@ -572,7 +889,26 @@ class RecordBatch:
 
 @typechecked
 class RecordBatchStreamWriter:
-    """Write RecordBatches to an Arrow IPC stream (file or buffer)."""
+    """
+    title: RecordBatchStreamWriter.
+    attributes:
+      _handle:
+        type: ctypes.c_void_p
+      _lib:
+        type: ctypes.CDLL
+      _is_buffer:
+        type: bool
+      _closed:
+        type: bool
+      _released:
+        type: bool
+    """
+
+    _handle: ctypes.c_void_p
+    _lib: ctypes.CDLL
+    _is_buffer: bool
+    _closed: bool
+    _released: bool
 
     def __init__(
         self,
@@ -580,6 +916,16 @@ class RecordBatchStreamWriter:
         lib: ctypes.CDLL,
         is_buffer: bool = False,
     ) -> None:
+        """
+        title: Wrap an existing native stream writer handle.
+        parameters:
+          handle:
+            type: ctypes.c_void_p
+          lib:
+            type: ctypes.CDLL
+          is_buffer:
+            type: bool
+        """
         self._handle = handle
         self._lib = lib
         self._is_buffer = is_buffer
@@ -590,6 +936,16 @@ class RecordBatchStreamWriter:
     def open_file(
         cls, schema: RecordBatchSchema, path: str | os.PathLike[str]
     ) -> "RecordBatchStreamWriter":
+        """
+        title: Open a stream writer backed by a file path.
+        parameters:
+          schema:
+            type: RecordBatchSchema
+          path:
+            type: str | os.PathLike[str]
+        returns:
+          type: RecordBatchStreamWriter
+        """
         lib = _get_lib()
         handle = ctypes.c_void_p()
         _check(
@@ -604,6 +960,14 @@ class RecordBatchStreamWriter:
     def open_buffer(
         cls, schema: RecordBatchSchema
     ) -> "RecordBatchStreamWriter":
+        """
+        title: Open a stream writer backed by an in-memory buffer.
+        parameters:
+          schema:
+            type: RecordBatchSchema
+        returns:
+          type: RecordBatchStreamWriter
+        """
         lib = _get_lib()
         handle = ctypes.c_void_p()
         _check(
@@ -615,6 +979,12 @@ class RecordBatchStreamWriter:
         return cls(handle, lib, is_buffer=True)
 
     def write_batch(self, batch: RecordBatch) -> None:
+        """
+        title: Write a completed batch to the stream.
+        parameters:
+          batch:
+            type: RecordBatch
+        """
         _check(
             self._lib.irx_rb_stream_writer_write_batch(
                 self._handle, batch._handle
@@ -623,6 +993,9 @@ class RecordBatchStreamWriter:
         )
 
     def close(self) -> None:
+        """
+        title: Close the underlying stream writer.
+        """
         if not self._closed:
             _check(
                 self._lib.irx_rb_stream_writer_close(self._handle), self._lib
@@ -631,8 +1004,9 @@ class RecordBatchStreamWriter:
 
     def buffer_data(self) -> bytes:
         """
-        Return the serialised IPC bytes (buffer writers only).
-        Must be called after close().
+        title: buffer_data.
+        returns:
+          type: bytes
         """
         if not self._is_buffer:
             raise RuntimeError(
@@ -651,17 +1025,35 @@ class RecordBatchStreamWriter:
         return bytes(ctypes.string_at(data_ptr, size.value))
 
     def release(self) -> None:
+        """
+        title: Release the underlying stream writer handle.
+        """
         if not self._released:
             self._lib.irx_rb_stream_writer_release(self._handle)
             self._released = True
 
     def __del__(self) -> None:
+        """
+        title: Release the writer when the object is garbage collected.
+        """
         self.release()
 
     def __enter__(self) -> "RecordBatchStreamWriter":
+        """
+        title: Support using the writer as a context manager.
+        returns:
+          type: RecordBatchStreamWriter
+        """
         return self
 
-    def __exit__(self, *exc: object) -> None:
+    def __exit__(self, *_exc: object) -> None:
+        """
+        title: Close and release the writer from a context manager.
+        parameters:
+          _exc:
+            type: object
+            variadic: positional
+        """
         self.close()
         self.release()
 
@@ -673,9 +1065,30 @@ class RecordBatchStreamWriter:
 
 @typechecked
 class RecordBatchStreamReader:
-    """Read RecordBatches from an Arrow IPC stream (file or buffer)."""
+    """
+    title: RecordBatchStreamReader.
+    attributes:
+      _handle:
+        type: ctypes.c_void_p
+      _lib:
+        type: ctypes.CDLL
+      _closed:
+        type: bool
+    """
+
+    _handle: ctypes.c_void_p
+    _lib: ctypes.CDLL
+    _closed: bool
 
     def __init__(self, handle: ctypes.c_void_p, lib: ctypes.CDLL) -> None:
+        """
+        title: Wrap an existing native stream reader handle.
+        parameters:
+          handle:
+            type: ctypes.c_void_p
+          lib:
+            type: ctypes.CDLL
+        """
         self._handle = handle
         self._lib = lib
         self._closed = False
@@ -684,6 +1097,14 @@ class RecordBatchStreamReader:
     def open_file(
         cls, path: str | os.PathLike[str]
     ) -> "RecordBatchStreamReader":
+        """
+        title: Open a stream reader backed by a file path.
+        parameters:
+          path:
+            type: str | os.PathLike[str]
+        returns:
+          type: RecordBatchStreamReader
+        """
         lib = _get_lib()
         handle = ctypes.c_void_p()
         _check(
@@ -696,6 +1117,14 @@ class RecordBatchStreamReader:
 
     @classmethod
     def open_buffer(cls, data: bytes) -> "RecordBatchStreamReader":
+        """
+        title: Open a stream reader backed by an in-memory buffer.
+        parameters:
+          data:
+            type: bytes
+        returns:
+          type: RecordBatchStreamReader
+        """
         lib = _get_lib()
         handle = ctypes.c_void_p()
         buf = (ctypes.c_uint8 * len(data)).from_buffer_copy(data)
@@ -709,8 +1138,9 @@ class RecordBatchStreamReader:
 
     def next_batch(self) -> Optional[RecordBatch]:
         """
-        Return the next RecordBatch or None at end-of-stream.
-        Caller is responsible for calling RecordBatch.release().
+        title: Return the next RecordBatch or None at end-of-stream.
+        returns:
+          type: Optional[RecordBatch]
         """
         batch_handle = ctypes.c_void_p()
         rc = self._lib.irx_rb_stream_reader_next_batch(
@@ -722,6 +1152,11 @@ class RecordBatchStreamReader:
         return RecordBatch(batch_handle, self._lib)
 
     def __iter__(self) -> Iterator[RecordBatch]:
+        """
+        title: Iterate batches from the stream until exhaustion.
+        returns:
+          type: Iterator[RecordBatch]
+        """
         batch = self.next_batch()
         while batch is not None:
             yield batch
@@ -729,15 +1164,33 @@ class RecordBatchStreamReader:
             batch = self.next_batch()
 
     def close(self) -> None:
+        """
+        title: Close the underlying stream reader.
+        """
         if not self._closed:
             self._lib.irx_rb_stream_reader_close(self._handle)
             self._closed = True
 
     def __del__(self) -> None:
+        """
+        title: Release the reader when the object is garbage collected.
+        """
         self.close()
 
     def __enter__(self) -> "RecordBatchStreamReader":
+        """
+        title: Support using the reader as a context manager.
+        returns:
+          type: RecordBatchStreamReader
+        """
         return self
 
-    def __exit__(self, *exc: object) -> None:
+    def __exit__(self, *_exc: object) -> None:
+        """
+        title: Close and release the reader from a context manager.
+        parameters:
+          _exc:
+            type: object
+            variadic: positional
+        """
         self.close()

--- a/packages/irx/tests/conftest.py
+++ b/packages/irx/tests/conftest.py
@@ -489,3 +489,24 @@ def llvm_visitor_in_function() -> LLVMVisitor:
     block = function.append_basic_block("entry")
     visitor._llvm.ir_builder = ir.IRBuilder(block)
     return visitor
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """
+    title: Build the record_batch ctypes shared library before collection.
+
+    ``tests/test_record_batch.py`` loads ``libirx_record_batch`` at import time
+    and skips itself when the library is absent. Build it best-effort here so
+    those tests actually run; failures (no compiler / no Arrow sources) leave
+    the library absent and the tests skip, as before.
+    """
+    try:
+        from irx.builder.runtime.record_batch import (
+            build_record_batch_shared_library,
+            shared_library_path,
+        )
+
+        if not shared_library_path().exists():
+            build_record_batch_shared_library()
+    except Exception as exc:  # noqa: BLE001 - best-effort; tests skip on failure
+        print(f"[conftest] record_batch native lib not built: {exc}")

--- a/packages/irx/tests/conftest.py
+++ b/packages/irx/tests/conftest.py
@@ -19,6 +19,10 @@ from irx.analysis import ModuleKey, ParsedModule
 from irx.builder import Builder as LLVMBuilder
 from irx.builder import Visitor as LLVMVisitor
 from irx.builder.base import Builder, CommandResult
+from irx.builder.runtime.record_batch import (
+    build_record_batch_shared_library,
+    shared_library_path,
+)
 from llvmlite import binding as llvm
 from llvmlite import ir
 
@@ -494,16 +498,14 @@ def llvm_visitor_in_function() -> LLVMVisitor:
 def pytest_configure(config: pytest.Config) -> None:
     """
     title: Build the record_batch native runtime before collection.
-
-    The native library is a first-class part of the feature and must be
-    available for its tests, mirroring the array runtime. Build it here so the
-    tests run against a fresh artifact. A build failure is NOT swallowed: the
-    native tests then fail loudly rather than silently passing.
+    summary: >-
+      The native library is a first-class part of the feature and must be
+      available for its tests, mirroring the array runtime. Build it here so
+      the tests run against a fresh artifact. A build failure is not swallowed:
+      the native tests then fail loudly rather than silently passing.
+    parameters:
+      config:
+        type: pytest.Config
     """
-    from irx.builder.runtime.record_batch import (
-        build_record_batch_shared_library,
-        shared_library_path,
-    )
-
     if not shared_library_path().exists():
         build_record_batch_shared_library()

--- a/packages/irx/tests/conftest.py
+++ b/packages/irx/tests/conftest.py
@@ -493,20 +493,17 @@ def llvm_visitor_in_function() -> LLVMVisitor:
 
 def pytest_configure(config: pytest.Config) -> None:
     """
-    title: Build the record_batch ctypes shared library before collection.
+    title: Build the record_batch native runtime before collection.
 
-    ``tests/test_record_batch.py`` loads ``libirx_record_batch`` at import time
-    and skips itself when the library is absent. Build it best-effort here so
-    those tests actually run; failures (no compiler / no Arrow sources) leave
-    the library absent and the tests skip, as before.
+    The native library is a first-class part of the feature and must be
+    available for its tests, mirroring the array runtime. Build it here so the
+    tests run against a fresh artifact. A build failure is NOT swallowed: the
+    native tests then fail loudly rather than silently passing.
     """
-    try:
-        from irx.builder.runtime.record_batch import (
-            build_record_batch_shared_library,
-            shared_library_path,
-        )
+    from irx.builder.runtime.record_batch import (
+        build_record_batch_shared_library,
+        shared_library_path,
+    )
 
-        if not shared_library_path().exists():
-            build_record_batch_shared_library()
-    except Exception as exc:  # noqa: BLE001 - best-effort; tests skip on failure
-        print(f"[conftest] record_batch native lib not built: {exc}")
+    if not shared_library_path().exists():
+        build_record_batch_shared_library()

--- a/packages/irx/tests/test_record_batch.py
+++ b/packages/irx/tests/test_record_batch.py
@@ -1,0 +1,379 @@
+"""
+tests/builder/runtime/test_record_batch.py
+
+Integration tests for RecordBatch streaming via the Arrow C++ bridge.
+
+These tests run the full native path:
+  Python API → ctypes → libirx_record_batch.so → Arrow C++ → IPC bytes
+
+They are skipped automatically when the native library has not been compiled
+(e.g. in documentation-only CI jobs).
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip guard — skip all tests when the native lib is unavailable
+# ---------------------------------------------------------------------------
+
+try:
+    from irx.record_batch import (
+        IrxColumnType,
+        RecordBatchBuilder,
+        RecordBatchSchema,
+        RecordBatchStreamReader,
+        RecordBatchStreamWriter,
+        _get_lib,
+    )
+
+    _get_lib()  # trigger load; raises if lib not found
+    _NATIVE_AVAILABLE = True
+except Exception:
+    _NATIVE_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not _NATIVE_AVAILABLE,
+    reason="IRx native library not compiled; skipping record_batch tests",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_simple_schema() -> RecordBatchSchema:
+    """Schema with one INT32 column and one FLOAT64 column."""
+    schema = RecordBatchSchema()
+    schema.add_field("id", IrxColumnType.INT32, nullable=False)
+    schema.add_field("value", IrxColumnType.FLOAT64, nullable=True)
+    return schema
+
+
+def fill_builder(builder: RecordBatchBuilder, n: int) -> None:
+    """Append n rows: id=i, value=i*1.5."""
+    for i in range(n):
+        builder.append_int32(0, i)
+        builder.append_float64(1, i * 1.5)
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_empty_schema(self):
+        s = RecordBatchSchema()
+        assert s.num_fields == 0
+        s.release()
+
+    def test_add_fields(self):
+        s = RecordBatchSchema()
+        s.add_field("a", IrxColumnType.INT32)
+        s.add_field("b", IrxColumnType.FLOAT64, nullable=False)
+        assert s.num_fields == 2
+        s.release()
+
+    def test_all_types(self):
+        s = RecordBatchSchema()
+        for ct in IrxColumnType:
+            s.add_field(ct.name.lower(), ct)
+        assert s.num_fields == len(IrxColumnType)
+        s.release()
+
+    def test_double_release_is_safe(self):
+        s = RecordBatchSchema()
+        s.release()
+        s.release()  # must not crash
+
+
+# ---------------------------------------------------------------------------
+# Builder / batch tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuilder:
+    def test_build_and_inspect(self):
+        schema = make_simple_schema()
+        builder = RecordBatchBuilder(schema)
+        fill_builder(builder, 4)
+        batch = builder.finish()
+
+        assert batch.num_rows == 4
+        assert batch.num_columns == 2
+
+        for i in range(4):
+            assert batch.get_int32(0, i) == i
+            assert math.isclose(batch.get_float64(1, i), i * 1.5)
+
+        batch.release()
+        builder.release()
+        schema.release()
+
+    def test_null_values(self):
+        schema = RecordBatchSchema()
+        schema.add_field("x", IrxColumnType.INT32, nullable=True)
+        builder = RecordBatchBuilder(schema)
+        builder.append_int32(0, 42)
+        builder.append_null(0)
+        builder.append_int32(0, 7)
+        batch = builder.finish()
+
+        assert batch.is_null(0, 0) is False
+        assert batch.is_null(0, 1) is True
+        assert batch.is_null(0, 2) is False
+        assert batch.get_int32(0, 0) == 42
+        assert batch.get_int32(0, 2) == 7
+
+        batch.release()
+        builder.release()
+        schema.release()
+
+    def test_bool_column(self):
+        schema = RecordBatchSchema()
+        schema.add_field("flag", IrxColumnType.BOOL)
+        builder = RecordBatchBuilder(schema)
+        builder.append_bool(0, True)
+        builder.append_bool(0, False)
+        builder.append_bool(0, True)
+        batch = builder.finish()
+
+        assert batch.get_bool(0, 0) is True
+        assert batch.get_bool(0, 1) is False
+        assert batch.get_bool(0, 2) is True
+        batch.release()
+        builder.release()
+        schema.release()
+
+    def test_all_numeric_types(self):
+        schema = RecordBatchSchema()
+        types_and_appenders = [
+            (IrxColumnType.INT8, "append_int8", "get_int8", -1),
+            (IrxColumnType.INT16, "append_int16", "get_int16", -2),
+            (IrxColumnType.INT32, "append_int32", "get_int32", -3),
+            (IrxColumnType.INT64, "append_int64", "get_int64", -4),
+            (IrxColumnType.UINT8, "append_uint8", "get_uint8", 5),
+            (IrxColumnType.UINT16, "append_uint16", "get_uint16", 6),
+            (IrxColumnType.UINT32, "append_uint32", "get_uint32", 7),
+            (IrxColumnType.UINT64, "append_uint64", "get_uint64", 8),
+            (IrxColumnType.FLOAT32, "append_float32", "get_float32", 1.5),
+            (IrxColumnType.FLOAT64, "append_float64", "get_float64", 2.5),
+        ]
+        for i, (ct, _, _, _) in enumerate(types_and_appenders):
+            schema.add_field(f"col_{i}", ct)
+
+        builder = RecordBatchBuilder(schema)
+        for i, (_, append_fn, _, value) in enumerate(types_and_appenders):
+            getattr(builder, append_fn)(i, value)
+        batch = builder.finish()
+
+        for i, (_, _, get_fn, expected) in enumerate(types_and_appenders):
+            got = getattr(batch, get_fn)(i, 0)
+            assert math.isclose(got, expected, rel_tol=1e-5), (
+                f"col {i}: got {got!r}, expected {expected!r}"
+            )
+
+        batch.release()
+        builder.release()
+        schema.release()
+
+    def test_oob_column_raises(self):
+        schema = RecordBatchSchema()
+        schema.add_field("x", IrxColumnType.INT32)
+        builder = RecordBatchBuilder(schema)
+        with pytest.raises(RuntimeError, match="out of bounds"):
+            builder.append_int32(99, 0)
+        builder.release()
+        schema.release()
+
+    def test_type_mismatch_raises(self):
+        schema = RecordBatchSchema()
+        schema.add_field("x", IrxColumnType.INT32)
+        builder = RecordBatchBuilder(schema)
+        with pytest.raises(RuntimeError, match="type mismatch"):
+            builder.append_float64(0, 3.14)
+        builder.release()
+        schema.release()
+
+    def test_empty_batch(self):
+        schema = make_simple_schema()
+        builder = RecordBatchBuilder(schema)
+        batch = builder.finish()
+        assert batch.num_rows == 0
+        batch.release()
+        builder.release()
+        schema.release()
+
+
+# ---------------------------------------------------------------------------
+# Stream writer / reader round-trip — in-memory buffer
+# ---------------------------------------------------------------------------
+
+
+class TestBufferRoundTrip:
+    def _write_batches(self, schema, batches_data):
+        writer = RecordBatchStreamWriter.open_buffer(schema)
+        for rows in batches_data:
+            builder = RecordBatchBuilder(schema)
+            for i in rows:
+                builder.append_int32(0, i)
+                builder.append_float64(1, float(i))
+            batch = builder.finish()
+            writer.write_batch(batch)
+            batch.release()
+            builder.release()
+        writer.close()
+        data = writer.buffer_data()
+        writer.release()
+        return data
+
+    def test_single_batch_round_trip(self):
+        schema = make_simple_schema()
+        data = self._write_batches(schema, [range(10)])
+
+        reader = RecordBatchStreamReader.open_buffer(data)
+        batch = reader.next_batch()
+        assert batch is not None
+        assert batch.num_rows == 10
+        for i in range(10):
+            assert batch.get_int32(0, i) == i
+            assert math.isclose(batch.get_float64(1, i), float(i))
+        batch.release()
+
+        assert reader.next_batch() is None  # EOF
+        reader.close()
+        schema.release()
+
+    def test_multiple_batches_round_trip(self):
+        schema = make_simple_schema()
+        data = self._write_batches(
+            schema, [range(5), range(5, 10), range(10, 15)]
+        )
+
+        reader = RecordBatchStreamReader.open_buffer(data)
+        all_ids = []
+        for batch in reader:  # uses __iter__
+            for row in range(batch.num_rows):
+                all_ids.append(batch.get_int32(0, row))
+        reader.close()
+
+        assert all_ids == list(range(15))
+        schema.release()
+
+    def test_empty_stream(self):
+        schema = make_simple_schema()
+        writer = RecordBatchStreamWriter.open_buffer(schema)
+        writer.close()
+        data = writer.buffer_data()
+        writer.release()
+
+        reader = RecordBatchStreamReader.open_buffer(data)
+        assert reader.next_batch() is None
+        reader.close()
+        schema.release()
+
+    def test_context_manager(self):
+        schema = make_simple_schema()
+        with RecordBatchStreamWriter.open_buffer(schema) as writer:
+            builder = RecordBatchBuilder(schema)
+            builder.append_int32(0, 99)
+            builder.append_float64(1, 99.0)
+            batch = builder.finish()
+            writer.write_batch(batch)
+            batch.release()
+            builder.release()
+            writer.close()
+            data = writer.buffer_data()
+
+        reader = RecordBatchStreamReader.open_buffer(data)
+        batch = reader.next_batch()
+        assert batch is not None
+        assert batch.get_int32(0, 0) == 99
+        batch.release()
+        reader.close()
+        schema.release()
+
+
+# ---------------------------------------------------------------------------
+# Stream writer / reader round-trip — file
+# ---------------------------------------------------------------------------
+
+
+class TestFileRoundTrip:
+    def test_file_round_trip(self, tmp_path):
+        path = tmp_path / "test.arrows"
+        schema = make_simple_schema()
+
+        writer = RecordBatchStreamWriter.open_file(schema, path)
+        builder = RecordBatchBuilder(schema)
+        for i in range(20):
+            builder.append_int32(0, i)
+            builder.append_float64(1, i * 0.5)
+        batch = builder.finish()
+        writer.write_batch(batch)
+        batch.release()
+        builder.release()
+        writer.close()
+        writer.release()
+
+        assert path.exists()
+        assert path.stat().st_size > 0
+
+        reader = RecordBatchStreamReader.open_file(str(path))
+        rb = reader.next_batch()
+        assert rb is not None
+        assert rb.num_rows == 20
+        for i in range(20):
+            assert rb.get_int32(0, i) == i
+            assert math.isclose(rb.get_float64(1, i), i * 0.5)
+        rb.release()
+        assert reader.next_batch() is None
+        reader.close()
+        schema.release()
+
+    def test_missing_file_raises(self):
+        with pytest.raises(RuntimeError):
+            RecordBatchStreamReader.open_file("/nonexistent/path.arrows")
+
+
+# ---------------------------------------------------------------------------
+# Large batch stress test
+# ---------------------------------------------------------------------------
+
+
+class TestLargeBatch:
+    @pytest.mark.parametrize("n", [1_000, 100_000])
+    def test_large_batch(self, n):
+        schema = RecordBatchSchema()
+        schema.add_field("x", IrxColumnType.INT64)
+        schema.add_field("y", IrxColumnType.FLOAT64)
+
+        writer = RecordBatchStreamWriter.open_buffer(schema)
+        builder = RecordBatchBuilder(schema)
+        for i in range(n):
+            builder.append_int64(0, i)
+            builder.append_float64(1, i * 3.14)
+        batch = builder.finish()
+        writer.write_batch(batch)
+        batch.release()
+        builder.release()
+        writer.close()
+        data = writer.buffer_data()
+        writer.release()
+
+        reader = RecordBatchStreamReader.open_buffer(data)
+        rb = reader.next_batch()
+        assert rb is not None
+        assert rb.num_rows == n
+        assert rb.get_int64(0, n - 1) == n - 1
+        assert math.isclose(
+            rb.get_float64(1, n - 1), (n - 1) * 3.14, rel_tol=1e-9
+        )
+        rb.release()
+        reader.close()
+        schema.release()

--- a/packages/irx/tests/test_record_batch.py
+++ b/packages/irx/tests/test_record_batch.py
@@ -6,8 +6,8 @@ Integration tests for RecordBatch streaming via the Arrow C++ bridge.
 These tests run the full native path:
   Python API → ctypes → libirx_record_batch.so → Arrow C++ → IPC bytes
 
-They are skipped automatically when the native library has not been compiled
-(e.g. in documentation-only CI jobs).
+The native runtime is a first-class part of the feature: like the array
+runtime tests, these always run and fail loudly if the library is missing.
 """
 
 from __future__ import annotations
@@ -17,34 +17,15 @@ import math
 import pyarrow as pa
 import pytest
 
-# ---------------------------------------------------------------------------
-# Skip guard — skip all tests when the native lib is unavailable
-# ---------------------------------------------------------------------------
-
-try:
-    from irx.record_batch import (
-        IrxColumnType,
-        RecordBatchBuilder,
-        RecordBatchSchema,
-        RecordBatchStreamReader,
-        RecordBatchStreamWriter,
-        _get_lib,
-    )
-
-    _get_lib()  # trigger load; raises if lib not found
-    _NATIVE_AVAILABLE = True
-except Exception:
-    _NATIVE_AVAILABLE = False
-
-pytestmark = pytest.mark.skipif(
-    not _NATIVE_AVAILABLE,
-    reason="IRx native library not compiled; skipping record_batch tests",
+from irx.record_batch import (
+    IrxColumnType,
+    RecordBatchBuilder,
+    RecordBatchSchema,
+    RecordBatchStreamReader,
+    RecordBatchStreamWriter,
 )
 
-
-# ---------------------------------------------------------------------------
 # Helpers
-# ---------------------------------------------------------------------------
 
 
 def make_simple_schema() -> RecordBatchSchema:
@@ -62,9 +43,7 @@ def fill_builder(builder: RecordBatchBuilder, n: int) -> None:
         builder.append_float64(1, i * 1.5)
 
 
-# ---------------------------------------------------------------------------
 # Schema tests
-# ---------------------------------------------------------------------------
 
 
 class TestSchema:
@@ -93,9 +72,7 @@ class TestSchema:
         s.release()  # must not crash
 
 
-# ---------------------------------------------------------------------------
 # Builder / batch tests
-# ---------------------------------------------------------------------------
 
 
 class TestBuilder:
@@ -211,9 +188,7 @@ class TestBuilder:
         schema.release()
 
 
-# ---------------------------------------------------------------------------
 # Stream writer / reader round-trip — in-memory buffer
-# ---------------------------------------------------------------------------
 
 
 class TestBufferRoundTrip:
@@ -300,9 +275,7 @@ class TestBufferRoundTrip:
         schema.release()
 
 
-# ---------------------------------------------------------------------------
 # Stream writer / reader round-trip — file
-# ---------------------------------------------------------------------------
 
 
 class TestFileRoundTrip:
@@ -342,9 +315,7 @@ class TestFileRoundTrip:
             RecordBatchStreamReader.open_file("/nonexistent/path.arrows")
 
 
-# ---------------------------------------------------------------------------
 # Large batch stress test
-# ---------------------------------------------------------------------------
 
 
 class TestLargeBatch:
@@ -380,9 +351,7 @@ class TestLargeBatch:
         schema.release()
 
 
-# ---------------------------------------------------------------------------
 # PyArrow IPC interop — the core ecosystem-compatibility guarantee
-# ---------------------------------------------------------------------------
 
 
 class TestPyArrowInterop:
@@ -454,7 +423,7 @@ class TestPyArrowInterop:
         reader.close()
 
     def test_irx_pyarrow_all_numeric_types(self):
-        """Every supported fixed-width column survives the IRx -> PyArrow trip."""
+        """Every fixed-width column survives the IRx -> PyArrow trip."""
         schema = RecordBatchSchema()
         schema.add_field("i8", IrxColumnType.INT8)
         schema.add_field("u32", IrxColumnType.UINT32)

--- a/packages/irx/tests/test_record_batch.py
+++ b/packages/irx/tests/test_record_batch.py
@@ -1,18 +1,12 @@
 """
-tests/builder/runtime/test_record_batch.py
-
-Integration tests for RecordBatch streaming via the Arrow C++ bridge.
-
-These tests run the full native path:
-  Python API → ctypes → libirx_record_batch.so → Arrow C++ → IPC bytes
-
-The native runtime is a first-class part of the feature: like the array
-runtime tests, these always run and fail loudly if the library is missing.
+title: Record batch streaming API.
 """
 
 from __future__ import annotations
 
 import math
+
+from pathlib import Path
 
 import pyarrow as pa
 import pytest
@@ -27,9 +21,27 @@ from irx.record_batch import (
 
 # Helpers
 
+EXPECTED_FIELD_COUNT = 2
+ROW_COUNT = 4
+NULL_ROW_INDEX = 2
+INT32_VALUE = 42
+INT32_VALUE_ALT = 7
+BATCH_ROW_COUNT = 10
+BATCH_ROW_COUNT_LARGE = 20
+PYARROW_ROW_COUNT = 5
+PYARROW_BATCH_ROW_COUNT = 3
+PYARROW_BATCH_COLUMN_COUNT = 2
+PYARROW_FIRST_INT32_VALUE = 10
+PYARROW_LAST_INT32_VALUE = 30
+PYARROW_CONTEXT_MANAGER_INT32_VALUE = 99
+
 
 def make_simple_schema() -> RecordBatchSchema:
-    """Schema with one INT32 column and one FLOAT64 column."""
+    """
+    title: Create a simple schema with one int32 and one float64 column.
+    returns:
+      type: RecordBatchSchema
+    """
     schema = RecordBatchSchema()
     schema.add_field("id", IrxColumnType.INT32, nullable=False)
     schema.add_field("value", IrxColumnType.FLOAT64, nullable=True)
@@ -37,7 +49,14 @@ def make_simple_schema() -> RecordBatchSchema:
 
 
 def fill_builder(builder: RecordBatchBuilder, n: int) -> None:
-    """Append n rows: id=i, value=i*1.5."""
+    """
+    title: Append a simple pattern of rows to a record-batch builder.
+    parameters:
+      builder:
+        type: RecordBatchBuilder
+      n:
+        type: int
+    """
     for i in range(n):
         builder.append_int32(0, i)
         builder.append_float64(1, i * 1.5)
@@ -48,18 +67,27 @@ def fill_builder(builder: RecordBatchBuilder, n: int) -> None:
 
 class TestSchema:
     def test_empty_schema(self):
+        """
+        title: Ensure an empty schema reports zero fields.
+        """
         s = RecordBatchSchema()
         assert s.num_fields == 0
         s.release()
 
     def test_add_fields(self):
+        """
+        title: Ensure schema fields can be added and counted.
+        """
         s = RecordBatchSchema()
         s.add_field("a", IrxColumnType.INT32)
         s.add_field("b", IrxColumnType.FLOAT64, nullable=False)
-        assert s.num_fields == 2
+        assert s.num_fields == EXPECTED_FIELD_COUNT
         s.release()
 
     def test_all_types(self):
+        """
+        title: Ensure every supported column type can be registered.
+        """
         s = RecordBatchSchema()
         for ct in IrxColumnType:
             s.add_field(ct.name.lower(), ct)
@@ -67,6 +95,9 @@ class TestSchema:
         s.release()
 
     def test_double_release_is_safe(self):
+        """
+        title: Ensure releasing a schema more than once is harmless.
+        """
         s = RecordBatchSchema()
         s.release()
         s.release()  # must not crash
@@ -77,15 +108,18 @@ class TestSchema:
 
 class TestBuilder:
     def test_build_and_inspect(self):
+        """
+        title: Ensure builders can create and inspect a simple batch.
+        """
         schema = make_simple_schema()
         builder = RecordBatchBuilder(schema)
         fill_builder(builder, 4)
         batch = builder.finish()
 
-        assert batch.num_rows == 4
-        assert batch.num_columns == 2
+        assert batch.num_rows == ROW_COUNT
+        assert batch.num_columns == EXPECTED_FIELD_COUNT
 
-        for i in range(4):
+        for i in range(ROW_COUNT):
             assert batch.get_int32(0, i) == i
             assert math.isclose(batch.get_float64(1, i), i * 1.5)
 
@@ -94,6 +128,9 @@ class TestBuilder:
         schema.release()
 
     def test_null_values(self):
+        """
+        title: Ensure null values are reported correctly.
+        """
         schema = RecordBatchSchema()
         schema.add_field("x", IrxColumnType.INT32, nullable=True)
         builder = RecordBatchBuilder(schema)
@@ -104,15 +141,18 @@ class TestBuilder:
 
         assert batch.is_null(0, 0) is False
         assert batch.is_null(0, 1) is True
-        assert batch.is_null(0, 2) is False
-        assert batch.get_int32(0, 0) == 42
-        assert batch.get_int32(0, 2) == 7
+        assert batch.is_null(0, NULL_ROW_INDEX) is False
+        assert batch.get_int32(0, 0) == INT32_VALUE
+        assert batch.get_int32(0, NULL_ROW_INDEX) == INT32_VALUE_ALT
 
         batch.release()
         builder.release()
         schema.release()
 
     def test_bool_column(self):
+        """
+        title: Ensure boolean columns round-trip through the builder.
+        """
         schema = RecordBatchSchema()
         schema.add_field("flag", IrxColumnType.BOOL)
         builder = RecordBatchBuilder(schema)
@@ -129,6 +169,9 @@ class TestBuilder:
         schema.release()
 
     def test_all_numeric_types(self):
+        """
+        title: Ensure all numeric column types are supported.
+        """
         schema = RecordBatchSchema()
         types_and_appenders = [
             (IrxColumnType.INT8, "append_int8", "get_int8", -1),
@@ -161,6 +204,9 @@ class TestBuilder:
         schema.release()
 
     def test_oob_column_raises(self):
+        """
+        title: Ensure out-of-bounds columns raise a runtime error.
+        """
         schema = RecordBatchSchema()
         schema.add_field("x", IrxColumnType.INT32)
         builder = RecordBatchBuilder(schema)
@@ -170,6 +216,9 @@ class TestBuilder:
         schema.release()
 
     def test_type_mismatch_raises(self):
+        """
+        title: Ensure type mismatches raise a runtime error.
+        """
         schema = RecordBatchSchema()
         schema.add_field("x", IrxColumnType.INT32)
         builder = RecordBatchBuilder(schema)
@@ -179,6 +228,9 @@ class TestBuilder:
         schema.release()
 
     def test_empty_batch(self):
+        """
+        title: Ensure an empty batch can be produced and inspected.
+        """
         schema = make_simple_schema()
         builder = RecordBatchBuilder(schema)
         batch = builder.finish()
@@ -192,7 +244,19 @@ class TestBuilder:
 
 
 class TestBufferRoundTrip:
-    def _write_batches(self, schema, batches_data):
+    def _write_batches(
+        self, schema: RecordBatchSchema, batches_data: list
+    ) -> bytes:
+        """
+        title: Write a list of batches into an in-memory stream.
+        parameters:
+          schema:
+            type: RecordBatchSchema
+          batches_data:
+            type: list
+        returns:
+          type: bytes
+        """
         writer = RecordBatchStreamWriter.open_buffer(schema)
         for rows in batches_data:
             builder = RecordBatchBuilder(schema)
@@ -209,14 +273,17 @@ class TestBufferRoundTrip:
         return data
 
     def test_single_batch_round_trip(self):
+        """
+        title: Ensure a single batch survives a buffer round-trip.
+        """
         schema = make_simple_schema()
         data = self._write_batches(schema, [range(10)])
 
         reader = RecordBatchStreamReader.open_buffer(data)
         batch = reader.next_batch()
         assert batch is not None
-        assert batch.num_rows == 10
-        for i in range(10):
+        assert batch.num_rows == BATCH_ROW_COUNT
+        for i in range(BATCH_ROW_COUNT):
             assert batch.get_int32(0, i) == i
             assert math.isclose(batch.get_float64(1, i), float(i))
         batch.release()
@@ -226,6 +293,9 @@ class TestBufferRoundTrip:
         schema.release()
 
     def test_multiple_batches_round_trip(self):
+        """
+        title: Ensure multiple batches survive a buffer round-trip.
+        """
         schema = make_simple_schema()
         data = self._write_batches(
             schema, [range(5), range(5, 10), range(10, 15)]
@@ -242,6 +312,9 @@ class TestBufferRoundTrip:
         schema.release()
 
     def test_empty_stream(self):
+        """
+        title: Ensure an empty stream yields no batches.
+        """
         schema = make_simple_schema()
         writer = RecordBatchStreamWriter.open_buffer(schema)
         writer.close()
@@ -254,6 +327,9 @@ class TestBufferRoundTrip:
         schema.release()
 
     def test_context_manager(self):
+        """
+        title: Ensure the writer and reader work as context managers.
+        """
         schema = make_simple_schema()
         with RecordBatchStreamWriter.open_buffer(schema) as writer:
             builder = RecordBatchBuilder(schema)
@@ -269,7 +345,7 @@ class TestBufferRoundTrip:
         reader = RecordBatchStreamReader.open_buffer(data)
         batch = reader.next_batch()
         assert batch is not None
-        assert batch.get_int32(0, 0) == 99
+        assert batch.get_int32(0, 0) == PYARROW_CONTEXT_MANAGER_INT32_VALUE
         batch.release()
         reader.close()
         schema.release()
@@ -279,7 +355,13 @@ class TestBufferRoundTrip:
 
 
 class TestFileRoundTrip:
-    def test_file_round_trip(self, tmp_path):
+    def test_file_round_trip(self, tmp_path: Path) -> None:
+        """
+        title: Ensure file-based streams round-trip correctly.
+        parameters:
+          tmp_path:
+            type: Path
+        """
         path = tmp_path / "test.arrows"
         schema = make_simple_schema()
 
@@ -301,8 +383,8 @@ class TestFileRoundTrip:
         reader = RecordBatchStreamReader.open_file(str(path))
         rb = reader.next_batch()
         assert rb is not None
-        assert rb.num_rows == 20
-        for i in range(20):
+        assert rb.num_rows == BATCH_ROW_COUNT_LARGE
+        for i in range(BATCH_ROW_COUNT_LARGE):
             assert rb.get_int32(0, i) == i
             assert math.isclose(rb.get_float64(1, i), i * 0.5)
         rb.release()
@@ -311,6 +393,9 @@ class TestFileRoundTrip:
         schema.release()
 
     def test_missing_file_raises(self):
+        """
+        title: Ensure opening a missing file raises a runtime error.
+        """
         with pytest.raises(RuntimeError):
             RecordBatchStreamReader.open_file("/nonexistent/path.arrows")
 
@@ -320,7 +405,13 @@ class TestFileRoundTrip:
 
 class TestLargeBatch:
     @pytest.mark.parametrize("n", [1_000, 100_000])
-    def test_large_batch(self, n):
+    def test_large_batch(self, n: int) -> None:
+        """
+        title: Ensure large batches can be written and read back.
+        parameters:
+          n:
+            type: int
+        """
         schema = RecordBatchSchema()
         schema.add_field("x", IrxColumnType.INT64)
         schema.add_field("y", IrxColumnType.FLOAT64)
@@ -355,11 +446,14 @@ class TestLargeBatch:
 
 
 class TestPyArrowInterop:
-    """IRx emits standard Arrow IPC stream bytes; verify PyArrow reads them
-    (and vice-versa), including null masks."""
+    """
+    title: TestPyArrowInterop.
+    """
 
     def test_irx_buffer_read_by_pyarrow(self):
-        """IRx writes a stream buffer; PyArrow imports and matches values."""
+        """
+        title: Ensure PyArrow can read IRx-written IPC bytes.
+        """
         schema = make_simple_schema()  # id INT32 non-null, value FLOAT64 null
         writer = RecordBatchStreamWriter.open_buffer(schema)
         builder = RecordBatchBuilder(schema)
@@ -381,7 +475,7 @@ class TestPyArrowInterop:
         # PyArrow consumes the IRx-produced IPC bytes directly.
         table = pa.ipc.open_stream(pa.py_buffer(data)).read_all()
 
-        assert table.num_rows == 5
+        assert table.num_rows == PYARROW_ROW_COUNT
         assert table.column_names == ["id", "value"]
         assert table.schema.field("id").type == pa.int32()
         assert table.schema.field("value").type == pa.float64()
@@ -389,7 +483,9 @@ class TestPyArrowInterop:
         assert table.column("value").to_pylist() == [0.0, None, 3.0, None, 6.0]
 
     def test_pyarrow_buffer_read_by_irx(self):
-        """PyArrow writes an IPC stream; the IRx reader imports it back."""
+        """
+        title: Ensure the IRx reader can import PyArrow-written IPC bytes.
+        """
         pa_schema = pa.schema(
             [
                 pa.field("id", pa.int32(), nullable=False),
@@ -411,10 +507,10 @@ class TestPyArrowInterop:
         reader = RecordBatchStreamReader.open_buffer(data)
         rb = reader.next_batch()
         assert rb is not None
-        assert rb.num_rows == 3
-        assert rb.num_columns == 2
-        assert rb.get_int32(0, 0) == 10
-        assert rb.get_int32(0, 2) == 30
+        assert rb.num_rows == PYARROW_BATCH_ROW_COUNT
+        assert rb.num_columns == PYARROW_BATCH_COLUMN_COUNT
+        assert rb.get_int32(0, 0) == PYARROW_FIRST_INT32_VALUE
+        assert rb.get_int32(0, 2) == PYARROW_LAST_INT32_VALUE
         assert math.isclose(rb.get_float64(1, 0), 1.5)
         assert rb.is_null(1, 1) is True
         assert math.isclose(rb.get_float64(1, 2), 4.5)
@@ -423,7 +519,10 @@ class TestPyArrowInterop:
         reader.close()
 
     def test_irx_pyarrow_all_numeric_types(self):
-        """Every fixed-width column survives the IRx -> PyArrow trip."""
+        """
+        title: >-
+          Ensure fixed-width numeric types survive the IRx to PyArrow trip.
+        """
         schema = RecordBatchSchema()
         schema.add_field("i8", IrxColumnType.INT8)
         schema.add_field("u32", IrxColumnType.UINT32)

--- a/packages/irx/tests/test_record_batch.py
+++ b/packages/irx/tests/test_record_batch.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import math
 
+import pyarrow as pa
 import pytest
 
 # ---------------------------------------------------------------------------
@@ -377,3 +378,110 @@ class TestLargeBatch:
         rb.release()
         reader.close()
         schema.release()
+
+
+# ---------------------------------------------------------------------------
+# PyArrow IPC interop — the core ecosystem-compatibility guarantee
+# ---------------------------------------------------------------------------
+
+
+class TestPyArrowInterop:
+    """IRx emits standard Arrow IPC stream bytes; verify PyArrow reads them
+    (and vice-versa), including null masks."""
+
+    def test_irx_buffer_read_by_pyarrow(self):
+        """IRx writes a stream buffer; PyArrow imports and matches values."""
+        schema = make_simple_schema()  # id INT32 non-null, value FLOAT64 null
+        writer = RecordBatchStreamWriter.open_buffer(schema)
+        builder = RecordBatchBuilder(schema)
+        for i in range(5):
+            builder.append_int32(0, i)
+            if i % 2 == 0:
+                builder.append_float64(1, i * 1.5)
+            else:
+                builder.append_null(1)
+        batch = builder.finish()
+        writer.write_batch(batch)
+        batch.release()
+        builder.release()
+        writer.close()
+        data = writer.buffer_data()
+        writer.release()
+        schema.release()
+
+        # PyArrow consumes the IRx-produced IPC bytes directly.
+        table = pa.ipc.open_stream(pa.py_buffer(data)).read_all()
+
+        assert table.num_rows == 5
+        assert table.column_names == ["id", "value"]
+        assert table.schema.field("id").type == pa.int32()
+        assert table.schema.field("value").type == pa.float64()
+        assert table.column("id").to_pylist() == [0, 1, 2, 3, 4]
+        assert table.column("value").to_pylist() == [0.0, None, 3.0, None, 6.0]
+
+    def test_pyarrow_buffer_read_by_irx(self):
+        """PyArrow writes an IPC stream; the IRx reader imports it back."""
+        pa_schema = pa.schema(
+            [
+                pa.field("id", pa.int32(), nullable=False),
+                pa.field("value", pa.float64(), nullable=True),
+            ]
+        )
+        record_batch = pa.record_batch(
+            [
+                pa.array([10, 20, 30], type=pa.int32()),
+                pa.array([1.5, None, 4.5], type=pa.float64()),
+            ],
+            schema=pa_schema,
+        )
+        sink = pa.BufferOutputStream()
+        with pa.ipc.new_stream(sink, pa_schema) as pa_writer:
+            pa_writer.write_batch(record_batch)
+        data = sink.getvalue().to_pybytes()
+
+        reader = RecordBatchStreamReader.open_buffer(data)
+        rb = reader.next_batch()
+        assert rb is not None
+        assert rb.num_rows == 3
+        assert rb.num_columns == 2
+        assert rb.get_int32(0, 0) == 10
+        assert rb.get_int32(0, 2) == 30
+        assert math.isclose(rb.get_float64(1, 0), 1.5)
+        assert rb.is_null(1, 1) is True
+        assert math.isclose(rb.get_float64(1, 2), 4.5)
+        rb.release()
+        assert reader.next_batch() is None
+        reader.close()
+
+    def test_irx_pyarrow_all_numeric_types(self):
+        """Every supported fixed-width column survives the IRx -> PyArrow trip."""
+        schema = RecordBatchSchema()
+        schema.add_field("i8", IrxColumnType.INT8)
+        schema.add_field("u32", IrxColumnType.UINT32)
+        schema.add_field("f32", IrxColumnType.FLOAT32)
+        schema.add_field("b", IrxColumnType.BOOL)
+
+        writer = RecordBatchStreamWriter.open_buffer(schema)
+        builder = RecordBatchBuilder(schema)
+        builder.append_int8(0, -5)
+        builder.append_uint32(1, 4_000_000_000)
+        builder.append_float32(2, 1.25)
+        builder.append_bool(3, True)
+        batch = builder.finish()
+        writer.write_batch(batch)
+        batch.release()
+        builder.release()
+        writer.close()
+        data = writer.buffer_data()
+        writer.release()
+        schema.release()
+
+        table = pa.ipc.open_stream(pa.py_buffer(data)).read_all()
+        assert table.schema.field("i8").type == pa.int8()
+        assert table.schema.field("u32").type == pa.uint32()
+        assert table.schema.field("f32").type == pa.float32()
+        assert table.schema.field("b").type == pa.bool_()
+        assert table.column("i8").to_pylist() == [-5]
+        assert table.column("u32").to_pylist() == [4_000_000_000]
+        assert math.isclose(table.column("f32").to_pylist()[0], 1.25)
+        assert table.column("b").to_pylist() == [True]


### PR DESCRIPTION
## Pull Request description
This PR adds a complete RecordBatch streaming layer to the IRx package,
backed by Arrow C++ and exposed through a stable pure-C ABI. It is the
next step after the existing single-array (irx_arrow_*) runtime: where that
layer handles one-dimensional Arrow arrays, this layer handles
arrow::RecordBatch, the portable unit of Arrow IPC.


<!-- Describe the purpose of your PR and the changes you have made. -->

<!-- Which issue this PR aims to resolve or fix? E.g.:
Solve #004
-->

## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] it includes tests.
- [ ] the tests are executed on CI.
- [ ] the tests generate log file(s) (path).
- [ ] pre-commit hooks were executed locally.
- [ ] this PR requires a project documentation update.

Author's checklist:

- [ ] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

<!-- Add any screenshot that helps to show the changes proposed -->

<!-- Add any other extra information that would help to understand the changes proposed by this PR -->

## Reviewer's checklist

Copy and paste this template for your review's note:

```
## Reviewer's Checklist

- [ ] I managed to reproduce the problem locally from the `main` branch
- [ ] I managed to test the new changes locally
- [ ] I confirm that the issues mentioned were fixed/resolved .
```
