### PR TITLE
feat(arxjit): add scalar type and signature API

### DIFF
--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -4,6 +4,16 @@ title: Top-level package for arxjit.
 
 from importlib import metadata as importlib_metadata
 
+from arxjit.types import (
+    ScalarType,
+    Signature,
+    bool_,
+    f32,
+    f64,
+    i32,
+    i64,
+)
+
 _DISTRIBUTION_NAME = "arxjit"
 
 
@@ -23,4 +33,14 @@ __author__: str = "Ivan Ogasawara"
 __email__: str = "ivan.ogasawara@gmail.com"
 __version__: str = get_version()
 
-__all__ = ["__version__", "get_version"]
+__all__ = [
+    "ScalarType",
+    "Signature",
+    "__version__",
+    "bool_",
+    "f32",
+    "f64",
+    "get_version",
+    "i32",
+    "i64",
+]

--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -5,8 +5,8 @@ title: Top-level package for arxjit.
 from importlib import metadata as importlib_metadata
 
 from arxjit.types import (
-    ScalarType,
     Signature,
+    SigType,
     bool_,
     f32,
     f64,
@@ -34,7 +34,7 @@ __email__: str = "ivan.ogasawara@gmail.com"
 __version__: str = get_version()
 
 __all__ = [
-    "ScalarType",
+    "SigType",
     "Signature",
     "__version__",
     "bool_",

--- a/packages/arxjit/src/arxjit/types.py
+++ b/packages/arxjit/src/arxjit/types.py
@@ -1,0 +1,84 @@
+"""
+title: Scalar type and signature API for arxjit.
+summary: >-
+  Defines the built-in scalar types (``i64``, ``f64`` ...) that users reference
+  in ``@jit`` signatures, and the ``Signature`` produced by calling a return
+  type with argument types, e.g. ``i64(i64, i64)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ScalarType:
+    """
+    title: A built-in scalar type usable in arxjit signatures.
+    attributes:
+      name:
+        type: str
+        description: The arxjit-facing name, e.g. ``i64``.
+      astx_name:
+        type: str
+        description: The astx class this scalar lowers to, e.g. ``Int64``.
+    """
+
+    name: str
+    astx_name: str
+
+    def __call__(self, *arg_types: ScalarType) -> Signature:
+        """
+        title: Build a Signature using this type as the return type.
+        parameters:
+          arg_types:
+            type: ScalarType
+            description: The positional argument types, in order.
+            variadic: positional
+        returns:
+          type: Signature
+        """
+        return Signature(return_type=self, arg_types=arg_types)
+
+    def __str__(self) -> str:
+        """
+        title: Return the arxjit name of the scalar type.
+        returns:
+          type: str
+        """
+        return self.name
+
+
+@dataclass(frozen=True)
+class Signature:
+    """
+    title: A compiled-function signature (return type and argument types).
+    attributes:
+      return_type:
+        type: ScalarType
+        description: The type returned by the compiled function.
+      arg_types:
+        type: tuple[ScalarType, Ellipsis]
+        description: The positional argument types, in order.
+    """
+
+    return_type: ScalarType
+    arg_types: tuple[ScalarType, ...]
+
+    def __str__(self) -> str:
+        """
+        title: Render the signature as ``ret(arg, arg)``.
+        returns:
+          type: str
+        """
+        args = ", ".join(str(arg) for arg in self.arg_types)
+        return f"{self.return_type}({args})"
+
+
+i32 = ScalarType("i32", "Int32")
+i64 = ScalarType("i64", "Int64")
+f32 = ScalarType("f32", "Float32")
+f64 = ScalarType("f64", "Float64")
+# Exported as ``bool_`` to avoid shadowing the ``bool`` builtin, but the
+# user-facing type name (used in signature rendering) stays ``bool``.
+bool_ = ScalarType("bool", "Boolean")

--- a/packages/arxjit/src/arxjit/types.py
+++ b/packages/arxjit/src/arxjit/types.py
@@ -12,27 +12,31 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class ScalarType:
+class SigType:
     """
-    title: A built-in scalar type usable in arxjit signatures.
+    title: A type usable in an arxjit signature.
+    summary: >-
+      Scalar today (e.g. ``i64``); the name is kept element-vs-array neutral so
+      array forms such as ``i64[2, 2]`` can be added later via subscripting
+      without renaming the public type.
     attributes:
       name:
         type: str
         description: The arxjit-facing name, e.g. ``i64``.
       astx_name:
         type: str
-        description: The astx class this scalar lowers to, e.g. ``Int64``.
+        description: The astx class this type lowers to, e.g. ``Int64``.
     """
 
     name: str
     astx_name: str
 
-    def __call__(self, *arg_types: ScalarType) -> Signature:
+    def __call__(self, *arg_types: SigType) -> Signature:
         """
         title: Build a Signature using this type as the return type.
         parameters:
           arg_types:
-            type: ScalarType
+            type: SigType
             description: The positional argument types, in order.
             variadic: positional
         returns:
@@ -42,7 +46,7 @@ class ScalarType:
 
     def __str__(self) -> str:
         """
-        title: Return the arxjit name of the scalar type.
+        title: Return the arxjit name of the type.
         returns:
           type: str
         """
@@ -55,15 +59,15 @@ class Signature:
     title: A compiled-function signature (return type and argument types).
     attributes:
       return_type:
-        type: ScalarType
+        type: SigType
         description: The type returned by the compiled function.
       arg_types:
-        type: tuple[ScalarType, Ellipsis]
+        type: tuple[SigType, Ellipsis]
         description: The positional argument types, in order.
     """
 
-    return_type: ScalarType
-    arg_types: tuple[ScalarType, ...]
+    return_type: SigType
+    arg_types: tuple[SigType, ...]
 
     def __str__(self) -> str:
         """
@@ -75,10 +79,10 @@ class Signature:
         return f"{self.return_type}({args})"
 
 
-i32 = ScalarType("i32", "Int32")
-i64 = ScalarType("i64", "Int64")
-f32 = ScalarType("f32", "Float32")
-f64 = ScalarType("f64", "Float64")
+i32 = SigType("i32", "Int32")
+i64 = SigType("i64", "Int64")
+f32 = SigType("f32", "Float32")
+f64 = SigType("f64", "Float64")
 # Exported as ``bool_`` to avoid shadowing the ``bool`` builtin, but the
 # user-facing type name (used in signature rendering) stays ``bool``.
-bool_ = ScalarType("bool", "Boolean")
+bool_ = SigType("bool", "Boolean")

--- a/packages/arxjit/tests/test_types.py
+++ b/packages/arxjit/tests/test_types.py
@@ -1,0 +1,94 @@
+"""
+title: Tests for the arxjit scalar type and signature API.
+"""
+
+import dataclasses
+
+import arxjit
+import astx
+import pytest
+
+from arxjit.types import ScalarType, Signature, bool_, f32, f64, i32, i64
+
+
+def test_call_builds_signature() -> None:
+    """
+    title: Calling a return type with arg types builds a Signature.
+    """
+    sig = i64(i64, i64)
+    assert isinstance(sig, Signature)
+    assert sig.return_type is i64
+    assert sig.arg_types == (i64, i64)
+
+
+def test_zero_argument_signature() -> None:
+    """
+    title: A return type called with no args yields an empty arg list.
+    """
+    sig = i64()
+    assert sig.return_type is i64
+    assert sig.arg_types == ()
+
+
+def test_scalar_str() -> None:
+    """
+    title: A scalar type stringifies to its arxjit name.
+    """
+    assert str(i64) == "i64"
+    assert str(f64) == "f64"
+    assert str(bool_) == "bool"
+
+
+def test_signature_str() -> None:
+    """
+    title: A signature renders as ``ret(arg, arg)``.
+    """
+    assert str(i64(i64, i64)) == "i64(i64, i64)"
+    assert str(f64(i32)) == "f64(i32)"
+    assert str(i64()) == "i64()"
+
+
+def test_scalar_types_map_to_real_astx_classes() -> None:
+    """
+    title: Each scalar's astx_name resolves to a real astx class.
+    """
+    for scalar in (i32, i64, f32, f64, bool_):
+        astx_cls = getattr(astx, scalar.astx_name)
+        assert isinstance(astx_cls, type)
+
+
+def test_scalar_type_equality_by_value() -> None:
+    """
+    title: ScalarType compares equal by value (frozen dataclass).
+    """
+    assert i64 == ScalarType("i64", "Int64")
+    assert i64 != i32
+
+
+def test_signature_equality_and_hashability() -> None:
+    """
+    title: Equal signatures compare equal and share a hash (cache keys).
+    """
+    assert i64(i64, i64) == i64(i64, i64)
+    assert i64(i64, i64) != i64(i64)
+    assert i64(i64) != f64(i64)
+    assert hash(i64(i64, i64)) == hash(i64(i64, i64))
+    assert len({i64(i64), i64(i64), f64(i64)}) == 2
+
+
+def test_scalar_type_is_immutable() -> None:
+    """
+    title: ScalarType instances cannot be mutated.
+    """
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        i64.name = "changed"  # type: ignore[misc]
+
+
+def test_types_are_exported_from_package() -> None:
+    """
+    title: The scalar types and Signature are exported from arxjit.
+    """
+    assert arxjit.i64 is i64
+    assert arxjit.Signature is Signature
+    for name in ("i32", "i64", "f32", "f64", "bool_", "ScalarType"):
+        assert name in arxjit.__all__

--- a/packages/arxjit/tests/test_types.py
+++ b/packages/arxjit/tests/test_types.py
@@ -8,7 +8,7 @@ import arxjit
 import astx
 import pytest
 
-from arxjit.types import ScalarType, Signature, bool_, f32, f64, i32, i64
+from arxjit.types import Signature, SigType, bool_, f32, f64, i32, i64
 
 
 def test_call_builds_signature() -> None:
@@ -57,11 +57,11 @@ def test_scalar_types_map_to_real_astx_classes() -> None:
         assert isinstance(astx_cls, type)
 
 
-def test_scalar_type_equality_by_value() -> None:
+def test_sigtype_equality_by_value() -> None:
     """
-    title: ScalarType compares equal by value (frozen dataclass).
+    title: SigType compares equal by value (frozen dataclass).
     """
-    assert i64 == ScalarType("i64", "Int64")
+    assert i64 == SigType("i64", "Int64")
     assert i64 != i32
 
 
@@ -76,9 +76,9 @@ def test_signature_equality_and_hashability() -> None:
     assert len({i64(i64), i64(i64), f64(i64)}) == 2
 
 
-def test_scalar_type_is_immutable() -> None:
+def test_sigtype_is_immutable() -> None:
     """
-    title: ScalarType instances cannot be mutated.
+    title: SigType instances cannot be mutated.
     """
     with pytest.raises(dataclasses.FrozenInstanceError):
         i64.name = "changed"  # type: ignore[misc]
@@ -90,5 +90,5 @@ def test_types_are_exported_from_package() -> None:
     """
     assert arxjit.i64 is i64
     assert arxjit.Signature is Signature
-    for name in ("i32", "i64", "f32", "f64", "bool_", "ScalarType"):
+    for name in ("i32", "i64", "f32", "f64", "bool_", "SigType"):
         assert name in arxjit.__all__


### PR DESCRIPTION
## Summary

Adds the first user-facing piece of arxjit: the scalar type and signature vocabulary (wiki Sprint 1 — *define the first supported scalar types and signature format*). Follow-up to the scaffold (#90); the `@jit` decorator that consumes these lands in the next PR.

```python
from arxjit import i64

sig = i64(i64, i64)   # Signature(return_type=i64, arg_types=(i64, i64))
str(sig)              # "i64(i64, i64)"
```

## What's included

- **`ScalarType`** — frozen dataclass; calling a type builds a `Signature`, enabling the Numba-style notation `i64(i64, i64)` from the wiki examples.
- **`Signature`** — frozen (hashable) return-type + arg-types pair, deliberately ready to serve as a specialization/cache key in the later caching sprints.
- **Scalar instances** `i32` / `i64` / `f32` / `f64` / `bool_`, each recording the astx class it lowers to (`i64 → astx.Int64`).
- 10 unit tests, including validation that every `astx_name` resolves to a real `astx` class, plus signature equality/hashability.

`types.py` stays import-light (no eager `astx` import), mirroring the lazy-import discipline used in pyarx.

## Two design points to confirm

1. **astx mapping as string vs class** — scalars carry `astx_name: str` (resolved lazily; validated in tests) rather than holding the `astx` class directly. Keeps signature-building dependency-free, but a typo would only surface at lowering time. Happy to switch to direct class references if you prefer fail-fast.
2. **Scalar set** — the wiki examples only use `i64`; this PR ships `i32`/`f32` too as the minimal family. Easy to trim to exactly `i64`/`f64`/`bool_` if you'd rather.

## Verification

Locally green: `pytest` (10/10), `ruff check`/`format`, `mypy --strict`, `douki sync` (idempotent), `vulture`, `bandit`.