### PR TITLE
ci: restore per-package code coverage gates in unittests tasks

### DIFF
--- a/.makim.yaml
+++ b/.makim.yaml
@@ -71,7 +71,9 @@ groups:
           params:
             help: Specify parameters to be used for tests
             type: string
-            default: "-vv"
+            default: >-
+              -vv --cov=arx --cov-fail-under=86
+              --cov-report=term-missing --no-cov-on-fail
         run: pytest ${{ args.path }} ${{ args.params }}
 
       test-compiled:
@@ -265,7 +267,9 @@ groups:
           params:
             help: Specify parameters to be used for tests
             type: string
-            default: "-vv"
+            default: >-
+              -vv --cov=aix --cov-fail-under=35
+              --cov-report=term-missing --no-cov-on-fail
         run: pytest ${{ args.path }} ${{ args.params }}
 
       test-compiled:
@@ -323,7 +327,9 @@ groups:
           params:
             help: Specify parameters to be used for tests
             type: string
-            default: "-vv"
+            default: >-
+              -vv --cov=astx --cov-fail-under=86
+              --cov-report=term-missing --no-cov-on-fail
         run: pytest ${{ args.path }} ${{ args.params }}
 
       format:
@@ -372,7 +378,9 @@ groups:
           params:
             help: Specify parameters to be used for tests
             type: string
-            default: "-vv"
+            default: >-
+              -vv --cov=irx --cov-fail-under=86
+              --cov-report=term-missing --no-cov-on-fail
         run: pytest ${{ args.path }} ${{ args.params }}
 
       test-analysis:
@@ -435,7 +443,9 @@ groups:
           params:
             help: Specify parameters to be used for tests
             type: string
-            default: "-vv"
+            default: >-
+              -vv --cov=pyarx --cov-fail-under=86
+              --cov-report=term-missing --no-cov-on-fail
         run: pytest ${{ args.path }} ${{ args.params }}
 
       format:
@@ -484,7 +494,9 @@ groups:
           params:
             help: Specify parameters to be used for tests
             type: string
-            default: "-vv"
+            default: >-
+              -vv --cov=arxjit --cov-fail-under=86
+              --cov-report=term-missing --no-cov-on-fail
         run: pytest ${{ args.path }} ${{ args.params }}
 
       format:


### PR DESCRIPTION
Restores per-package code coverage gating in the `unittests` makim tasks. Coverage was dropped in the monorepo migration (#72) — the old single-package task ran `pytest --cov=arx --cov-fail-under=90 ...`; since then no package has had coverage wired in, even though `pytest-cov`/`coverage` are still root dev-dependencies and `makim clean` still wipes coverage artifacts.

## What this does

Each package's `unittests` task now defaults to:

```
-vv --cov=<pkg> --cov-fail-under=<threshold> --cov-report=term-missing --no-cov-on-fail
```

CI needs no workflow change: it already runs `makim <pkg>.unittests` with default args, so the gate applies to every cell of the test matrix. `.gitignore` already covers `.coverage`/`htmlcov`.

## Thresholds (as agreed on Discord)

Measured coverage today (py3.11, exact totals):

| Package | Coverage | Gate |
| ------- | -------- | ---- |
| arx     | 89.51%   | 86   |
| astx    | 86.53%   | 86   |
| irx     | 86.68%   | 86   |
| pyarx   | 94.12%   | 86   |
| arxjit  | 100%     | 86   |
| aix     | 37.41%   | 35   |

- **86** is the highest uniform bar that is green today: `--cov-fail-under` compares the *exact* total (no rounding), so the originally proposed 87 would fail astx (86.53) and irx (86.68) immediately. The bar can be ratcheted up as tests land.
- **aix gets a 35 floor** for now: most aix behavior is exercised by its compiled-language tests (`aix test-compiled`), which pytest coverage does not count, so its unit-test coverage understates real coverage. To be ratcheted up as aix unit tests are added.

## Design notes

- The coverage flags live in the **`params` default**, not the `run:` line, so the documented single-test workflow (`makim arx.unittests --path ... --params "-k foo"`) is not blocked by the coverage gate — passing `--params` opts out of it. The default (and therefore CI) always gates.
- `--no-cov-on-fail` keeps failing-test output readable by skipping the coverage report when tests fail.

## Verification

All six gates run locally with the exact task defaults: arx 357 passed, astx 473 passed, irx 850 passed, pyarx 13 passed, arxjit 17 passed, aix 19 passed — every `--cov-fail-under` gate green.
