### PR TITLE
feat(arxjit): add structured diagnostics and the public error hierarchy

### DIFF
--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -8,7 +8,7 @@ from arxjit.core import JitFunction, jit
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
 from arxjit.errors import (
     ArxJitError,
-    SourceUnavailableError,
+    SourceExtractionError,
     UnsupportedSyntaxError,
 )
 from arxjit.types import (
@@ -47,7 +47,7 @@ __all__ = [
     "JitFunction",
     "SigType",
     "Signature",
-    "SourceUnavailableError",
+    "SourceExtractionError",
     "UnsupportedSyntaxError",
     "__version__",
     "bool_",

--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -5,6 +5,12 @@ title: Top-level package for arxjit.
 from importlib import metadata as importlib_metadata
 
 from arxjit.core import JitFunction, jit
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.errors import (
+    ArxJitError,
+    SourceUnavailableError,
+    UnsupportedSyntaxError,
+)
 from arxjit.types import (
     Signature,
     SigType,
@@ -35,9 +41,14 @@ __email__: str = "ivan.ogasawara@gmail.com"
 __version__: str = get_version()
 
 __all__ = [
+    "ArxJitError",
+    "Diagnostic",
+    "DiagnosticSeverity",
     "JitFunction",
     "SigType",
     "Signature",
+    "SourceUnavailableError",
+    "UnsupportedSyntaxError",
     "__version__",
     "bool_",
     "f32",

--- a/packages/arxjit/src/arxjit/diagnostics.py
+++ b/packages/arxjit/src/arxjit/diagnostics.py
@@ -46,7 +46,11 @@ class Diagnostic:
         description: One-based source line in ``filename``, when known.
       column:
         type: int | None
-        description: One-based source column, when known.
+        description: >-
+          One-based Unicode character column in ``line``, when known. Python
+          AST ``col_offset`` values (zero-based UTF-8 byte offsets) must be
+          converted to this representation at the boundary that produces the
+          diagnostic, never stored raw.
       code:
         type: str | None
         description: Stable diagnostic code, e.g. "AJ001", when assigned.

--- a/packages/arxjit/src/arxjit/diagnostics.py
+++ b/packages/arxjit/src/arxjit/diagnostics.py
@@ -1,0 +1,84 @@
+"""
+title: Structured diagnostic records for arxjit.
+summary: >-
+  Define the frozen Diagnostic record and the DiagnosticSeverity enum that
+  arxjit uses to report problems found while extracting, validating, or
+  compiling a decorated Python function. Diagnostics point at the user's Python
+  source (the file and line of the decorated function), so messages stay
+  actionable without exposing compiler internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class DiagnosticSeverity(Enum):
+    """
+    title: Severity level of a diagnostic.
+    """
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+    HINT = "hint"
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """
+    title: One structured diagnostic reported by arxjit.
+    attributes:
+      severity:
+        type: DiagnosticSeverity
+        description: The severity level of the diagnostic.
+      message:
+        type: str
+        description: The human-readable diagnostic message.
+      filename:
+        type: str
+        description: >-
+          The file defining the decorated function, or "<unknown>" when the
+          source cannot be attributed.
+      line:
+        type: int | None
+        description: One-based source line in ``filename``, when known.
+      column:
+        type: int | None
+        description: One-based source column, when known.
+      code:
+        type: str | None
+        description: Stable diagnostic code, e.g. "AJ001", when assigned.
+    """
+
+    severity: DiagnosticSeverity
+    message: str
+    filename: str
+    line: int | None
+    column: int | None
+    code: str | None = None
+
+    def __str__(self) -> str:
+        """
+        title: Render the diagnostic as one human-readable line.
+        summary: >-
+          Format is ``file:line:column: severity: [code] message``. Unknown
+          location parts are omitted (a column is only rendered when the line
+          is also known), and an unset or empty code renders no bracket prefix.
+        returns:
+          type: str
+        """
+        location = self.filename
+        if self.line is not None:
+            location = f"{location}:{self.line}"
+            if self.column is not None:
+                location = f"{location}:{self.column}"
+        prefix = f"[{self.code}] " if self.code else ""
+        return f"{location}: {self.severity.value}: {prefix}{self.message}"
+
+
+__all__ = [
+    "Diagnostic",
+    "DiagnosticSeverity",
+]

--- a/packages/arxjit/src/arxjit/errors.py
+++ b/packages/arxjit/src/arxjit/errors.py
@@ -2,7 +2,7 @@
 title: Public exception hierarchy for arxjit.
 summary: >-
   Define the single error hierarchy arxjit raises to callers: ArxJitError as
-  the base, with SourceUnavailableError for functions whose source cannot be
+  the base, with SourceExtractionError for functions whose source cannot be
   retrieved and parsed, and UnsupportedSyntaxError for functions using Python
   constructs outside the supported subset. Each error carries a list of
   structured Diagnostic records so callers can inspect failures
@@ -45,13 +45,15 @@ class ArxJitError(Exception):
         super().__init__(message)
 
 
-class SourceUnavailableError(ArxJitError):
+class SourceExtractionError(ArxJitError):
     """
-    title: Raised when a decorated function's source cannot be obtained.
+    title: Raised when a decorated function's source cannot be extracted.
     summary: >-
-      Covers functions whose source cannot be retrieved and parsed as a
-      standalone function definition, such as ones defined in the REPL, built
-      with exec, implemented in C, or lambdas.
+      Covers the whole extraction stage, functions whose source cannot be
+      retrieved or cannot be parsed as a standalone function definition, such
+      as ones defined in the REPL, built with exec, implemented in C, or
+      lambdas. Constructs rejected after successful extraction raise
+      UnsupportedSyntaxError instead.
     attributes:
       diagnostics:
         type: list[Diagnostic]
@@ -73,6 +75,6 @@ class UnsupportedSyntaxError(ArxJitError):
 
 __all__ = [
     "ArxJitError",
-    "SourceUnavailableError",
+    "SourceExtractionError",
     "UnsupportedSyntaxError",
 ]

--- a/packages/arxjit/src/arxjit/errors.py
+++ b/packages/arxjit/src/arxjit/errors.py
@@ -1,0 +1,78 @@
+"""
+title: Public exception hierarchy for arxjit.
+summary: >-
+  Define the single error hierarchy arxjit raises to callers: ArxJitError as
+  the base, with SourceUnavailableError for functions whose source cannot be
+  retrieved and parsed, and UnsupportedSyntaxError for functions using Python
+  constructs outside the supported subset. Each error carries a list of
+  structured Diagnostic records so callers can inspect failures
+  programmatically instead of scraping message text.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from arxjit.diagnostics import Diagnostic
+
+
+class ArxJitError(Exception):
+    """
+    title: Base class for every error raised by arxjit.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+        description: Structured diagnostics describing the failure.
+    """
+
+    diagnostics: list[Diagnostic]
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        diagnostics: Sequence[Diagnostic] | None = None,
+    ) -> None:
+        """
+        title: Initialize an ArxJitError.
+        parameters:
+          message:
+            type: str
+          diagnostics:
+            type: Sequence[Diagnostic] | None
+        """
+        self.diagnostics = list(diagnostics or ())
+        super().__init__(message)
+
+
+class SourceUnavailableError(ArxJitError):
+    """
+    title: Raised when a decorated function's source cannot be obtained.
+    summary: >-
+      Covers functions whose source cannot be retrieved and parsed as a
+      standalone function definition, such as ones defined in the REPL, built
+      with exec, implemented in C, or lambdas.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+    """
+
+
+class UnsupportedSyntaxError(ArxJitError):
+    """
+    title: Raised when a function uses Python outside the supported subset.
+    summary: >-
+      Carries one diagnostic per rejected construct, each pointing at the
+      offending source line, so a function with several unsupported constructs
+      reports all of them at once.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+    """
+
+
+__all__ = [
+    "ArxJitError",
+    "SourceUnavailableError",
+    "UnsupportedSyntaxError",
+]

--- a/packages/arxjit/tests/test_diagnostics.py
+++ b/packages/arxjit/tests/test_diagnostics.py
@@ -1,0 +1,122 @@
+"""
+title: Tests for the arxjit diagnostic records.
+"""
+
+import dataclasses
+
+import arxjit
+import pytest
+
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+
+_BASE = Diagnostic(
+    severity=DiagnosticSeverity.ERROR,
+    message="lambda is not supported",
+    filename="example.py",
+    line=3,
+    column=5,
+)
+
+
+def _diagnostic(**overrides: object) -> Diagnostic:
+    """
+    title: Build a valid Diagnostic, overriding selected fields.
+    parameters:
+      overrides:
+        type: object
+        description: Field values replacing the base diagnostic's.
+        variadic: keyword
+    returns:
+      type: Diagnostic
+    """
+    return dataclasses.replace(_BASE, **overrides)
+
+
+def test_severity_values() -> None:
+    """
+    title: The severity enum exposes the four expected levels.
+    """
+    assert DiagnosticSeverity.ERROR.value == "error"
+    assert DiagnosticSeverity.WARNING.value == "warning"
+    assert DiagnosticSeverity.INFO.value == "info"
+    assert DiagnosticSeverity.HINT.value == "hint"
+
+
+def test_code_defaults_to_none() -> None:
+    """
+    title: The diagnostic code is optional and defaults to None.
+    """
+    assert _diagnostic().code is None
+
+
+def test_diagnostic_is_immutable() -> None:
+    """
+    title: Diagnostic instances cannot be mutated.
+    """
+    diagnostic = _diagnostic()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        diagnostic.message = "changed"  # type: ignore[misc]
+
+
+def test_diagnostic_equality_by_value() -> None:
+    """
+    title: Diagnostics with identical fields compare equal.
+    """
+    assert _diagnostic() == _diagnostic()
+    assert _diagnostic() != _diagnostic(line=4)
+
+
+def test_str_with_full_location() -> None:
+    """
+    title: A fully-located diagnostic renders file, line, and column.
+    """
+    assert str(_diagnostic()) == (
+        "example.py:3:5: error: lambda is not supported"
+    )
+
+
+def test_str_without_column() -> None:
+    """
+    title: A diagnostic without a column renders file and line only.
+    """
+    assert str(_diagnostic(column=None)) == (
+        "example.py:3: error: lambda is not supported"
+    )
+
+
+def test_str_without_location() -> None:
+    """
+    title: A diagnostic without line or column renders the file only.
+    """
+    assert str(_diagnostic(line=None, column=None)) == (
+        "example.py: error: lambda is not supported"
+    )
+
+
+def test_str_drops_column_when_line_is_unknown() -> None:
+    """
+    title: A column without a line is omitted from the rendering.
+    """
+    assert str(_diagnostic(line=None)) == (
+        "example.py: error: lambda is not supported"
+    )
+
+
+def test_str_with_code() -> None:
+    """
+    title: An assigned diagnostic code renders in brackets.
+    """
+    assert str(_diagnostic(code="AJ001")) == (
+        "example.py:3:5: error: [AJ001] lambda is not supported"
+    )
+    assert str(_diagnostic(code="")) == str(_diagnostic())
+
+
+def test_diagnostics_are_exported_from_package() -> None:
+    """
+    title: Diagnostic and DiagnosticSeverity are exported from arxjit.
+    """
+    assert arxjit.Diagnostic is Diagnostic
+    assert arxjit.DiagnosticSeverity is DiagnosticSeverity
+    for name in ("Diagnostic", "DiagnosticSeverity"):
+        assert name in arxjit.__all__

--- a/packages/arxjit/tests/test_errors.py
+++ b/packages/arxjit/tests/test_errors.py
@@ -1,0 +1,82 @@
+"""
+title: Tests for the arxjit exception hierarchy.
+"""
+
+import arxjit
+import pytest
+
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.errors import (
+    ArxJitError,
+    SourceUnavailableError,
+    UnsupportedSyntaxError,
+)
+
+_DIAGNOSTIC = Diagnostic(
+    severity=DiagnosticSeverity.ERROR,
+    message="lambda is not supported",
+    filename="example.py",
+    line=3,
+    column=5,
+)
+
+
+def test_base_error_message() -> None:
+    """
+    title: The error message is exposed through str().
+    """
+    assert str(ArxJitError("extraction failed")) == "extraction failed"
+
+
+def test_diagnostics_default_to_empty_list() -> None:
+    """
+    title: An error built without diagnostics carries an empty list.
+    """
+    assert ArxJitError("failed").diagnostics == []
+
+
+def test_diagnostics_are_copied() -> None:
+    """
+    title: The diagnostics sequence is copied defensively.
+    """
+    source: list[Diagnostic] = [_DIAGNOSTIC]
+    error = ArxJitError("failed", diagnostics=source)
+    source.clear()
+    assert error.diagnostics == [_DIAGNOSTIC]
+
+
+def test_subclasses_are_arxjit_errors() -> None:
+    """
+    title: Every public error subclasses ArxJitError and Exception.
+    """
+    for error_type in (SourceUnavailableError, UnsupportedSyntaxError):
+        error = error_type("failed", diagnostics=[_DIAGNOSTIC])
+        assert isinstance(error, ArxJitError)
+        assert isinstance(error, Exception)
+        assert error.diagnostics == [_DIAGNOSTIC]
+
+
+def test_errors_are_catchable_as_base() -> None:
+    """
+    title: A raised subclass is catchable as ArxJitError.
+    """
+    with pytest.raises(ArxJitError) as caught:
+        raise UnsupportedSyntaxError(
+            "unsupported syntax", diagnostics=[_DIAGNOSTIC]
+        )
+    assert caught.value.diagnostics == [_DIAGNOSTIC]
+
+
+def test_errors_are_exported_from_package() -> None:
+    """
+    title: The exception hierarchy is exported from arxjit.
+    """
+    assert arxjit.ArxJitError is ArxJitError
+    assert arxjit.SourceUnavailableError is SourceUnavailableError
+    assert arxjit.UnsupportedSyntaxError is UnsupportedSyntaxError
+    for name in (
+        "ArxJitError",
+        "SourceUnavailableError",
+        "UnsupportedSyntaxError",
+    ):
+        assert name in arxjit.__all__

--- a/packages/arxjit/tests/test_errors.py
+++ b/packages/arxjit/tests/test_errors.py
@@ -8,7 +8,7 @@ import pytest
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
 from arxjit.errors import (
     ArxJitError,
-    SourceUnavailableError,
+    SourceExtractionError,
     UnsupportedSyntaxError,
 )
 
@@ -49,7 +49,7 @@ def test_subclasses_are_arxjit_errors() -> None:
     """
     title: Every public error subclasses ArxJitError and Exception.
     """
-    for error_type in (SourceUnavailableError, UnsupportedSyntaxError):
+    for error_type in (SourceExtractionError, UnsupportedSyntaxError):
         error = error_type("failed", diagnostics=[_DIAGNOSTIC])
         assert isinstance(error, ArxJitError)
         assert isinstance(error, Exception)
@@ -72,11 +72,11 @@ def test_errors_are_exported_from_package() -> None:
     title: The exception hierarchy is exported from arxjit.
     """
     assert arxjit.ArxJitError is ArxJitError
-    assert arxjit.SourceUnavailableError is SourceUnavailableError
+    assert arxjit.SourceExtractionError is SourceExtractionError
     assert arxjit.UnsupportedSyntaxError is UnsupportedSyntaxError
     for name in (
         "ArxJitError",
-        "SourceUnavailableError",
+        "SourceExtractionError",
         "UnsupportedSyntaxError",
     ):
         assert name in arxjit.__all__


### PR DESCRIPTION
## What

First PR of arxjit Sprint 2 (source extraction + Python AST validation), per the 4-PR split posted in the Discord thread:

- `arxjit.diagnostics` — frozen `Diagnostic` record (`severity, message, filename, line, column, code`) + `DiagnosticSeverity` enum (`ERROR/WARNING/INFO/HINT`), with a human-readable `__str__` (`file:line:col: error: [code] message`).
- `arxjit.errors` — `ArxJitError` base carrying `list[Diagnostic]`, with `SourceUnavailableError` (source cannot be retrieved and parsed as a standalone function definition: REPL, `exec`, C functions, lambdas) and `UnsupportedSyntaxError` (constructs outside the v1 subset), mapping 1:1 to the two Sprint 2 layers.
- Both exported from the package root; 16 new tests (arxjit coverage stays 100%).

## Why diagnostics before extraction/validation

Both upcoming layers report user-facing failures — extraction fails on source-less functions, and validation's whole job is rejecting unsupported syntax with clear messages (wiki Issue 4). Landing the shared vocabulary first (~90 lines) means both PRs raise the same typed errors from day one instead of ad-hoc strings retrofitted later.

## Design notes

- Same 6-field diagnostic contract as pyarx (reviewed in #86), so both packages speak one convention — but **no cross-import**: arxjit stays standalone, and none of pyarx's irx-translation machinery is carried over. arxjit diagnostics point at the user's real Python file/line via `ast` nodes.
- `code` (e.g. `AJ001`) is optional and unassigned for now; the validation PR can introduce stable codes if wanted.
- Per the Discord decision: default behavior on rejected functions will be warn + fall back to plain Python, with a boolean `strict`-style parameter on `@jit` to force-raise — that lands in the validation wiring PR, where these exceptions get raised.

## Checks

- pytest: 33 passed, arxjit coverage 100% (gate 86)
- ruff format + check, mypy strict (`mypy src`), bandit, vulture, mccabe: clean
- `douki sync` run and idempotent (second run: 0 updated)