### PR TITLE
feat(arxjit): add source extraction for decorated functions

### DIFF
--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -11,6 +11,7 @@ from arxjit.errors import (
     SourceExtractionError,
     UnsupportedSyntaxError,
 )
+from arxjit.source import ExtractedSource, extract_source
 from arxjit.types import (
     Signature,
     SigType,
@@ -44,6 +45,7 @@ __all__ = [
     "ArxJitError",
     "Diagnostic",
     "DiagnosticSeverity",
+    "ExtractedSource",
     "JitFunction",
     "SigType",
     "Signature",
@@ -51,6 +53,7 @@ __all__ = [
     "UnsupportedSyntaxError",
     "__version__",
     "bool_",
+    "extract_source",
     "f32",
     "f64",
     "get_version",

--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -1,0 +1,176 @@
+"""
+title: Source extraction for @jit-decorated Python functions.
+summary: >-
+  First stage of the arxjit pipeline: retrieve the source of a decorated
+  function, normalize its indentation, drop the decorator lines, and parse the
+  remaining function definition with Python's built-in ast module. A retrieved
+  source that is not a single function definition raises SourceExtractionError
+  carrying structured diagnostics; validating the parsed body against the
+  supported Python subset is a later stage and is not done here.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+from dataclasses import dataclass
+from typing import Any, Callable, cast
+
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.errors import SourceExtractionError
+
+PyFunc = Callable[..., Any]
+
+
+def _filename_of(fn: PyFunc) -> str:
+    """
+    title: Return the filename a function was defined in.
+    summary: >-
+      Reads the function's code object; falls back to "<unknown>" for objects
+      without one (for example C builtins).
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: str
+    """
+    code = getattr(fn, "__code__", None)
+    filename = getattr(code, "co_filename", None)
+    return filename or "<unknown>"
+
+
+def _name_of(fn: PyFunc) -> str:
+    """
+    title: Return a human-readable name for a function.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: str
+    """
+    return cast(str, getattr(fn, "__qualname__", repr(fn)))
+
+
+def _error(
+    message: str,
+    filename: str,
+    line: int | None = None,
+    column: int | None = None,
+) -> Diagnostic:
+    """
+    title: Build an ERROR-severity diagnostic.
+    parameters:
+      message:
+        type: str
+      filename:
+        type: str
+      line:
+        type: int | None
+      column:
+        type: int | None
+    returns:
+      type: Diagnostic
+    """
+    return Diagnostic(
+        severity=DiagnosticSeverity.ERROR,
+        message=message,
+        filename=filename,
+        line=line,
+        column=column,
+    )
+
+
+@dataclass(frozen=True)
+class ExtractedSource:
+    """
+    title: The extracted, normalized source of a decorated function.
+    attributes:
+      filename:
+        type: str
+        description: The file defining the function, or "<unknown>".
+      source:
+        type: str
+        description: >-
+          Dedented source of the function definition with the decorator lines
+          removed; its first line is the def statement.
+      lineno:
+        type: int
+        description: One-based line of the def statement in ``filename``.
+      node:
+        type: ast.FunctionDef | ast.AsyncFunctionDef
+        description: >-
+          The parsed function definition. Line numbers are shifted to match
+          ``filename``, so they can be reported in diagnostics directly. Column
+          offsets are left as raw ast ``col_offset`` values (zero-based UTF-8
+          byte offsets) and must be converted at the boundary that produces a
+          diagnostic.
+    """
+
+    filename: str
+    source: str
+    lineno: int
+    node: ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def extract_source(fn: PyFunc) -> ExtractedSource:
+    """
+    title: Extract and parse the source of a decorated function.
+    summary: >-
+      Retrieves the source block with inspect.getsourcelines, normalizes
+      indentation with textwrap.dedent so nested functions and methods parse as
+      top-level code, removes the decorator lines, and parses the function
+      definition with ast.parse. The returned node keeps real file line
+      numbers; async definitions are extracted here and left for the validation
+      stage to accept or reject.
+    parameters:
+      fn:
+        type: PyFunc
+        description: The undecorated Python function to extract.
+    returns:
+      type: ExtractedSource
+    raises:
+      SourceExtractionError: >-
+        If the retrieved source is not a single function definition (for
+        example a lambda).
+    """
+    filename = _filename_of(fn)
+    block_lines, block_start = inspect.getsourcelines(fn)
+    block = textwrap.dedent("".join(block_lines))
+    module = ast.parse(block, filename=filename)
+
+    if len(module.body) != 1 or not isinstance(
+        module.body[0], (ast.FunctionDef, ast.AsyncFunctionDef)
+    ):
+        message = (
+            f"source of {_name_of(fn)!r} is not a single function"
+            " definition (lambdas are not supported)"
+        )
+        raise SourceExtractionError(
+            message,
+            diagnostics=[_error(message, filename, block_start)],
+        )
+
+    located = module.body[0]
+    def_lineno = block_start + located.lineno - 1
+    lines = block.splitlines(keepends=True)
+    source = "".join(lines[located.lineno - 1 :])
+
+    stripped = ast.parse(source, filename=filename)
+    ast.increment_lineno(stripped, def_lineno - 1)
+    # `source` starts at the def line, so the sole statement is the
+    # function definition itself.
+    node = cast("ast.FunctionDef | ast.AsyncFunctionDef", stripped.body[0])
+    return ExtractedSource(
+        filename=filename,
+        source=source,
+        lineno=def_lineno,
+        node=node,
+    )
+
+
+__all__ = [
+    "ExtractedSource",
+    "extract_source",
+]

--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -2,9 +2,12 @@
 title: Source extraction for @jit-decorated Python functions.
 summary: >-
   First stage of the arxjit pipeline: retrieve the source of a decorated
-  function, normalize its indentation, drop the decorator lines, and parse the
-  remaining function definition with Python's built-in ast module. A retrieved
-  source that is not a single function definition raises SourceExtractionError
+  function, parse it with Python's built-in ast module, and drop the
+  decorators. The source text is never modified: an indented definition (a
+  nested function or a method) is parsed inside a synthetic "if True:" wrapper
+  instead of being dedented, which preserves string literal content and keeps
+  every node's line and column pointing into the real file. A retrieved source
+  that is not a single function definition raises SourceExtractionError
   carrying structured diagnostics; validating the parsed body against the
   supported Python subset is a later stage and is not done here.
 """
@@ -13,7 +16,6 @@ from __future__ import annotations
 
 import ast
 import inspect
-import textwrap
 
 from dataclasses import dataclass
 from typing import Any, Callable, cast
@@ -23,19 +25,26 @@ from arxjit.errors import SourceExtractionError
 
 PyFunc = Callable[..., Any]
 
+_WRAPPER = "if True:\n"
+_WRAPPER_LINES = 1
+
 
 def _filename_of(fn: PyFunc) -> str:
     """
     title: Return the filename a function was defined in.
     summary: >-
-      Reads the function's code object; falls back to "<unknown>" for objects
-      without one (for example C builtins).
+      Follows __wrapped__ chains first, because inspect.getsourcelines does the
+      same and the filename must match the source it returns; a JitFunction
+      wrapper is therefore attributed to the file of the function it wraps.
+      Reads the unwrapped function's code object; falls back to "<unknown>" for
+      objects without one (for example C builtins).
     parameters:
       fn:
         type: PyFunc
     returns:
       type: str
     """
+    fn = inspect.unwrap(fn)
     code = getattr(fn, "__code__", None)
     filename = getattr(code, "co_filename", None)
     return filename or "<unknown>"
@@ -85,7 +94,7 @@ def _error(
 @dataclass(frozen=True)
 class ExtractedSource:
     """
-    title: The extracted, normalized source of a decorated function.
+    title: The extracted source of a decorated function.
     attributes:
       filename:
         type: str
@@ -93,19 +102,22 @@ class ExtractedSource:
       source:
         type: str
         description: >-
-          Dedented source of the function definition with the decorator lines
-          removed; its first line is the def statement.
+          Verbatim file text of the function definition with the decorator
+          lines removed; the first line is the def statement, and the original
+          indentation is preserved so string literals are untouched.
       lineno:
         type: int
         description: One-based line of the def statement in ``filename``.
       node:
         type: ast.FunctionDef | ast.AsyncFunctionDef
         description: >-
-          The parsed function definition. Line numbers are shifted to match
-          ``filename``, so they can be reported in diagnostics directly. Column
-          offsets are left as raw ast ``col_offset`` values (zero-based UTF-8
-          byte offsets) and must be converted at the boundary that produces a
-          diagnostic.
+          The parsed function definition with an empty decorator list. Line
+          numbers match ``filename``, so they can be reported in diagnostics
+          directly. Column offsets are raw ast ``col_offset`` values (zero-
+          based UTF-8 byte offsets) that point into the real file line, because
+          the source is parsed without modifying its indentation; only the
+          byte-to-character conversion is needed at the boundary that produces
+          a diagnostic.
     """
 
     filename: str
@@ -118,16 +130,17 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
     """
     title: Extract and parse the source of a decorated function.
     summary: >-
-      Retrieves the source block with inspect.getsourcelines, normalizes
-      indentation with textwrap.dedent so nested functions and methods parse as
-      top-level code, removes the decorator lines, and parses the function
-      definition with ast.parse. The returned node keeps real file line
-      numbers; async definitions are extracted here and left for the validation
-      stage to accept or reject.
+      Retrieves the source block with inspect.getsourcelines (which follows
+      __wrapped__, so a JitFunction resolves to the function it wraps) and
+      parses it with ast.parse. An indented block is parsed inside a synthetic
+      "if True:" wrapper rather than dedented, so the text is never modified
+      and every node keeps real file lines and columns. The decorators are
+      dropped from the returned node and source; async definitions are
+      extracted here and left for the validation stage to accept or reject.
     parameters:
       fn:
         type: PyFunc
-        description: The undecorated Python function to extract.
+        description: The Python function to extract.
     returns:
       type: ExtractedSource
     raises:
@@ -137,12 +150,23 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
     """
     filename = _filename_of(fn)
     block_lines, block_start = inspect.getsourcelines(fn)
-    block = textwrap.dedent("".join(block_lines))
-    module = ast.parse(block, filename=filename)
+    block = "".join(block_lines)
+    indented = block_lines[0] != block_lines[0].lstrip()
 
-    if len(module.body) != 1 or not isinstance(
-        module.body[0], (ast.FunctionDef, ast.AsyncFunctionDef)
-    ):
+    if indented:
+        text = _WRAPPER + block
+        line_delta = block_start - _WRAPPER_LINES - 1
+    else:
+        text = block
+        line_delta = block_start - 1
+    module = ast.parse(text, filename=filename)
+    if indented:
+        body = cast("ast.If", module.body[0]).body
+    else:
+        body = module.body
+
+    node = body[0] if len(body) == 1 else None
+    if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
         message = (
             f"source of {_name_of(fn)!r} is not a single function"
             " definition (lambdas are not supported)"
@@ -152,16 +176,10 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
             diagnostics=[_error(message, filename, block_start)],
         )
 
-    located = module.body[0]
-    def_lineno = block_start + located.lineno - 1
-    lines = block.splitlines(keepends=True)
-    source = "".join(lines[located.lineno - 1 :])
-
-    stripped = ast.parse(source, filename=filename)
-    ast.increment_lineno(stripped, def_lineno - 1)
-    # `source` starts at the def line, so the sole statement is the
-    # function definition itself.
-    node = cast("ast.FunctionDef | ast.AsyncFunctionDef", stripped.body[0])
+    ast.increment_lineno(node, line_delta)
+    node.decorator_list = []
+    def_lineno = node.lineno
+    source = "".join(block_lines[def_lineno - block_start :])
     return ExtractedSource(
         filename=filename,
         source=source,

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -1,0 +1,235 @@
+"""
+title: Tests for source extraction.
+"""
+
+import ast
+import dataclasses
+
+from typing import Any, Callable
+
+import arxjit
+import pytest
+
+from arxjit.diagnostics import DiagnosticSeverity
+from arxjit.errors import SourceExtractionError
+from arxjit.source import ExtractedSource, extract_source
+
+PyFunc = Callable[..., Any]
+
+
+def _passthrough(fn: PyFunc) -> PyFunc:
+    """
+    title: Return the decorated function unchanged.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: PyFunc
+    """
+    return fn
+
+
+def _configured(**_options: Any) -> Callable[[PyFunc], PyFunc]:
+    """
+    title: Return a passthrough decorator built from keyword options.
+    parameters:
+      _options:
+        type: Any
+        variadic: keyword
+    returns:
+      type: Callable[[PyFunc], PyFunc]
+    """
+    return _passthrough
+
+
+def sample_add(a: int, b: int) -> int:
+    """
+    title: Add two integers.
+    parameters:
+      a:
+        type: int
+      b:
+        type: int
+    returns:
+      type: int
+    """
+    return a + b
+
+
+@_passthrough
+@_passthrough
+def sample_decorated(x: int) -> int:
+    """
+    title: Double an integer, behind two stacked decorators.
+    parameters:
+      x:
+        type: int
+    returns:
+      type: int
+    """
+    return x * 2
+
+
+@_configured(
+    cache=True,
+    strict=False,
+)
+def sample_multiline_decorated(x: int) -> int:
+    """
+    title: Negate an integer, behind a multi-line decorator call.
+    parameters:
+      x:
+        type: int
+    returns:
+      type: int
+    """
+    return -x
+
+
+async def sample_async(x: int) -> int:
+    """
+    title: Return the argument, asynchronously.
+    parameters:
+      x:
+        type: int
+    returns:
+      type: int
+    """
+    return x
+
+
+sample_lambda = lambda x: x * x  # noqa: E731
+
+
+def _file_line(lineno: int) -> str:
+    """
+    title: Return the given one-based line of this test file.
+    parameters:
+      lineno:
+        type: int
+    returns:
+      type: str
+    """
+    with open(__file__, encoding="utf-8") as stream:
+        return stream.readlines()[lineno - 1]
+
+
+def test_plain_function_is_extracted() -> None:
+    """
+    title: A plain module-level function extracts cleanly.
+    """
+    extracted = extract_source(sample_add)
+    assert isinstance(extracted, ExtractedSource)
+    assert extracted.filename == __file__
+    assert extracted.source.startswith("def sample_add(")
+    assert extracted.node.name == "sample_add"
+    assert "def sample_add(" in _file_line(extracted.lineno)
+
+
+def test_node_line_numbers_match_the_file() -> None:
+    """
+    title: Line numbers on the parsed node point into the real file.
+    """
+    extracted = extract_source(sample_add)
+    assert extracted.node.lineno == extracted.lineno
+    returns = [
+        stmt
+        for stmt in ast.walk(extracted.node)
+        if isinstance(stmt, ast.Return)
+    ]
+    assert len(returns) == 1
+    assert "return a + b" in _file_line(returns[0].lineno)
+
+
+def test_decorator_lines_are_removed() -> None:
+    """
+    title: Stacked decorator lines are stripped from source and node.
+    """
+    extracted = extract_source(sample_decorated)
+    assert extracted.source.startswith("def sample_decorated(")
+    assert extracted.node.decorator_list == []
+    assert "def sample_decorated(" in _file_line(extracted.lineno)
+
+
+def test_multiline_decorator_is_removed() -> None:
+    """
+    title: A multi-line decorator call is stripped entirely.
+    """
+    extracted = extract_source(sample_multiline_decorated)
+    assert extracted.source.startswith("def sample_multiline_decorated(")
+    assert "cache=True" not in extracted.source
+    assert "def sample_multiline_decorated(" in _file_line(extracted.lineno)
+
+
+def test_nested_function_is_dedented() -> None:
+    """
+    title: A function defined inside another parses after dedenting.
+    """
+
+    def nested(x: int) -> int:
+        """
+        title: Increment an integer.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x + 1
+
+    extracted = extract_source(nested)
+    assert extracted.source.startswith("def nested(")
+    assert extracted.node.name == "nested"
+
+
+def test_extracted_source_reparses_standalone() -> None:
+    """
+    title: The decorator-free source parses as a standalone module.
+    """
+    extracted = extract_source(sample_decorated)
+    module = ast.parse(extracted.source)
+    assert len(module.body) == 1
+    function = module.body[0]
+    assert isinstance(function, ast.FunctionDef)
+    assert function.name == "sample_decorated"
+
+
+def test_async_function_is_extracted() -> None:
+    """
+    title: An async function extracts; rejecting it is validation's job.
+    """
+    extracted = extract_source(sample_async)
+    assert isinstance(extracted.node, ast.AsyncFunctionDef)
+    assert extracted.source.startswith("async def sample_async(")
+
+
+def test_lambda_is_rejected() -> None:
+    """
+    title: A lambda raises SourceExtractionError with one diagnostic.
+    """
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_lambda)
+    assert "not a single function definition" in str(caught.value)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.severity is DiagnosticSeverity.ERROR
+    assert diagnostic.filename == __file__
+    assert diagnostic.line is not None
+
+
+def test_extracted_source_is_frozen() -> None:
+    """
+    title: ExtractedSource instances are immutable.
+    """
+    extracted = extract_source(sample_add)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        extracted.lineno = 1  # type: ignore[misc]
+
+
+def test_extraction_is_exported_from_package() -> None:
+    """
+    title: The extraction API is exported from arxjit.
+    """
+    assert arxjit.extract_source is extract_source
+    assert arxjit.ExtractedSource is ExtractedSource
+    for name in ("ExtractedSource", "extract_source"):
+        assert name in arxjit.__all__

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -4,12 +4,14 @@ title: Tests for source extraction.
 
 import ast
 import dataclasses
+import functools
 
 from typing import Any, Callable
 
 import arxjit
 import pytest
 
+from arxjit.core import JitFunction, jit
 from arxjit.diagnostics import DiagnosticSeverity
 from arxjit.errors import SourceExtractionError
 from arxjit.source import ExtractedSource, extract_source
@@ -161,9 +163,12 @@ def test_multiline_decorator_is_removed() -> None:
     assert "def sample_multiline_decorated(" in _file_line(extracted.lineno)
 
 
-def test_nested_function_is_dedented() -> None:
+def test_nested_function_is_extracted_verbatim() -> None:
     """
-    title: A function defined inside another parses after dedenting.
+    title: A function defined inside another parses without dedenting.
+    summary: >-
+      The source keeps its original indentation, and the def line of the
+      returned verbatim text is exactly the line found in the real file.
     """
 
     def nested(x: int) -> int:
@@ -178,8 +183,78 @@ def test_nested_function_is_dedented() -> None:
         return x + 1
 
     extracted = extract_source(nested)
-    assert extracted.source.startswith("def nested(")
     assert extracted.node.name == "nested"
+    assert extracted.source.lstrip().startswith("def nested(")
+    assert extracted.source.splitlines()[0] + "\n" == _file_line(
+        extracted.lineno
+    )
+
+
+def test_nested_function_with_multiline_string_is_extracted() -> None:
+    """
+    title: Zero-indent lines inside string literals do not break parsing.
+    summary: >-
+      textwrap.dedent would compute a common indentation of zero for this block
+      and the parse would fail with IndentationError; parsing the unmodified
+      block inside the synthetic wrapper succeeds and preserves the string
+      content verbatim.
+    """
+
+    def nested() -> str:
+        """
+        title: Return a two-line string.
+        returns:
+          type: str
+        """
+        value = """first
+second
+"""
+        return value
+
+    extracted = extract_source(nested)
+    assert extracted.node.name == "nested"
+    constants = [
+        item.value
+        for item in ast.walk(extracted.node)
+        if isinstance(item, ast.Constant)
+        and isinstance(item.value, str)
+        and "second" in item.value
+    ]
+    assert constants == ["first\nsecond\n"]
+
+
+def test_column_offsets_point_into_the_real_file() -> None:
+    """
+    title: Column offsets on nested-function nodes are file-true.
+    summary: >-
+      The source is parsed without removing indentation, so col_offset values
+      index into the real file line (as byte offsets) and need no indentation
+      correction at the diagnostic boundary.
+    """
+
+    def nested(x: int) -> int:
+        """
+        title: Increment an integer.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x + 1
+
+    extracted = extract_source(nested)
+    returns = [
+        stmt
+        for stmt in ast.walk(extracted.node)
+        if isinstance(stmt, ast.Return)
+    ]
+    assert len(returns) == 1
+    line = _file_line(returns[0].lineno)
+    assert line[returns[0].col_offset :].startswith("return x + 1")
+    assert line[returns[0].col_offset : returns[0].end_col_offset] == (
+        "return x + 1"
+    )
 
 
 def test_extracted_source_reparses_standalone() -> None:
@@ -201,6 +276,64 @@ def test_async_function_is_extracted() -> None:
     extracted = extract_source(sample_async)
     assert isinstance(extracted.node, ast.AsyncFunctionDef)
     assert extracted.source.startswith("async def sample_async(")
+
+
+def test_jit_function_is_extracted_with_filename() -> None:
+    """
+    title: Extracting an actual @jit result keeps the real filename.
+    summary: >-
+      JitFunction sets __wrapped__ via functools.update_wrapper, so both the
+      source retrieval and the filename attribution must resolve to the wrapped
+      function; the extraction also strips the @jit decorator line.
+    """
+
+    @jit
+    def doubled(x: int) -> int:
+        """
+        title: Double an integer.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * 2
+
+    assert isinstance(doubled, JitFunction)
+    extracted = extract_source(doubled)
+    assert extracted.filename == __file__
+    assert extracted.node.name == "doubled"
+    assert extracted.node.decorator_list == []
+    assert extracted.source.lstrip().startswith("def doubled(")
+    assert "def doubled(" in _file_line(extracted.lineno)
+
+
+def test_wrapped_function_is_attributed_to_the_original_file() -> None:
+    """
+    title: A wraps-style wrapper extracts the original, filename included.
+    summary: >-
+      inspect.getsourcelines follows __wrapped__, so the extracted source is
+      the original function's; the reported filename must belong to the same
+      function, even when the wrapper's own code lives in another file.
+    """
+    namespace: dict[str, Any] = {
+        "functools": functools,
+        "sample_add": sample_add,
+    }
+    exec(
+        compile(
+            "@functools.wraps(sample_add)\n"
+            "def wrapper(*args, **kwargs):\n"
+            "    return sample_add(*args, **kwargs)\n",
+            "<wrapper>",
+            "exec",
+        ),
+        namespace,
+    )
+    extracted = extract_source(namespace["wrapper"])
+    assert extracted.filename == __file__
+    assert extracted.node.name == "sample_add"
+    assert "def sample_add(" in _file_line(extracted.lineno)
 
 
 def test_lambda_is_rejected() -> None:


### PR DESCRIPTION
## Summary

Sprint 2, source extraction (wiki "Proposed Issue 3: Implement Python function source extraction"). This is the second of the four small Sprint 2 PRs agreed on Discord, building on the diagnostics/error layer merged in #95.

It adds `arxjit.source.extract_source()`, the first stage of the `@jit` pipeline: given the decorated Python function, produce a decorator-free source string and a parsed `ast` function node that the upcoming validation pass (and later the Python-AST -> ASTx lowering) can consume.

> **Updated after review (6e93497):** the original version dedented the block with `textwrap.dedent` before parsing. Per the review findings, the source text is now **never modified** — indented definitions are parsed inside a synthetic `if True:` wrapper that preserves lexical content, and `__wrapped__` chains are unwrapped before filename attribution. `ExtractedSource.source` is therefore *verbatim* file text (not a normalized representation, and for nested functions not standalone-parseable); the parsed `node` is the canonical artifact. A normalized source representation for the cache-key work is tracked in #97.

Issue 3 checklist coverage:

- [x] Retrieve the source code of decorated Python functions — `inspect.getsourcelines` (follows `__wrapped__`, so an actual `JitFunction` resolves to the function it wraps)
- [x] Normalize indentation — reinterpreted after review: indented blocks (nested functions, methods) are made parseable via the synthetic wrapper while the text itself stays verbatim, so string literals and column offsets are untouched. Explicit source normalization is deferred to #97.
- [x] Remove the decorator layer before parsing — see "How stripping works" below
- [x] Parse the function source using Python's built-in `ast` module
- [ ] Provide clear errors when source extraction is unavailable — **follow-up PR** (already built and stacked on this branch), so each PR stays small. This PR ships the one error case it structurally needs: a retrieved source that is not a single function definition (e.g. a lambda) raises `SourceExtractionError` with a structured `Diagnostic`, because returning an `ExtractedSource` for it would be wrong.

## What it returns

`ExtractedSource` (frozen dataclass):

| field | meaning |
|---|---|
| `filename` | file defining the (unwrapped) function, or `"<unknown>"` |
| `source` | verbatim file text from the `def` line to the end of the function; decorator lines removed, original indentation preserved |
| `lineno` | 1-based line of the `def` statement in `filename` |
| `node` | parsed `ast.FunctionDef \| ast.AsyncFunctionDef` with an empty decorator list |

Two properties worth calling out:

- **Node line numbers point into the user's real file** (`ast.increment_lineno` after the parse). The validation pass can put `node.lineno` straight into a `Diagnostic` without any offset bookkeeping.
- **Column offsets are file-true.** Because the text is never dedented, `col_offset` / `end_col_offset` index into the real file line (as 0-based UTF-8 byte offsets). Per the column contract from #95, the only remaining step at the diagnostic-producing boundary is the byte-to-character conversion.

## How stripping works

The block returned by `inspect.getsourcelines` includes the decorators. If its first line is indented, the block is parsed as `"if True:\n" + block` — this preserves every byte of the original text (multiline strings with zero-indent lines parse fine, unlike with `textwrap.dedent`). `FunctionDef.lineno` always points at the `def` line (decorators live separately in `decorator_list`), so the verbatim `source` slice starts there and the node's `decorator_list` is emptied. The result has no decorators by construction rather than by pattern-matching.

## Design decisions to review

1. **`async def` extracts successfully** (hence the `FunctionDef | AsyncFunctionDef` union). Rejecting async is the validation pass's job, so users get a proper "unsupported construct" diagnostic with a location instead of a confusing extraction failure.
2. **`Diagnostic.code` stays `None`** — no stable code scheme (AJ001, ...) exists yet; I'd propose introducing one in the validation PR where the per-construct diagnostics land.
3. **`extract_source` / `ExtractedSource` are exported from `arxjit`** — useful for the debug/introspection sprint later; easy to make private if you prefer.
4. **`PyFunc` alias is duplicated from `core.py`** instead of imported, to avoid a `core <-> source` import cycle once the decorator wiring PR makes `core` import `source`.

## Verification

- 14 extraction tests (47 total), arxjit coverage 100%; line-number assertions read the test file itself so they don't rot when the file is edited. Includes one regression test per review finding: a nested function containing a multiline string with zero-indent lines, file-true `col_offset`/`end_col_offset` on a nested function, and `extract_source` on an actual `@jit` result.
- The stdlib behaviors the implementation relies on were probed on local CPython 3.10, 3.11, 3.13 and 3.14 (matching the CI matrix): `FunctionDef.lineno` is the `def` line under multi-line decorators, `increment_lineno` shifts `end_lineno` too, and constructs that are valid syntax but unsupported semantics (`nonlocal`, `yield`, methods) parse fine standalone and flow through to validation as intended.
- Verified end-to-end in IPython (the original Colab demo environment): a `@jit`-decorated function defined in a cell extracts cleanly — decorator stripped, `<ipython-input-...>` filename (including when extracting the `JitFunction` itself), cell-relative line numbers.
- All gates green locally: pytest + the 86% coverage gate, ruff format/check, mypy strict, bandit, vulture, mccabe, and `douki sync` idempotent.
