### PR TITLE
feat(arxjit): add clear errors when source extraction is unavailable

### DIFF
--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import ast
 import inspect
+import tokenize
 
 from dataclasses import dataclass
 from typing import Any, Callable, cast
@@ -65,6 +66,29 @@ def _name_of(fn: PyFunc) -> str:
       type: str
     """
     return cast(str, getattr(fn, "__qualname__", repr(fn)))
+
+
+def _retrieval_reason(exc: Exception) -> str:
+    """
+    title: Return a clean, location-free message for a retrieval failure.
+    summary: >-
+      inspect.getsourcelines can fail with exception types whose str() embeds a
+      location: a tokenize.TokenError carries a (message, position) tuple, and
+      a SyntaxError appends its own line number. No reliable file location
+      exists at retrieval time (it fails before the block's start line is
+      known), so only the human-readable message is used, never an embedded
+      position.
+    parameters:
+      exc:
+        type: Exception
+    returns:
+      type: str
+    """
+    if isinstance(exc, tokenize.TokenError):
+        return str(exc.args[0]) if exc.args else str(exc)
+    if isinstance(exc, SyntaxError):
+        return exc.msg or str(exc)
+    return str(exc)
 
 
 def _column_of(exc: SyntaxError, text: str) -> int | None:
@@ -234,15 +258,27 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
     raises:
       SourceExtractionError: >-
         If the source cannot be retrieved (REPL- or exec-defined functions, C
-        builtins, self-referential wrappers), cannot be parsed (including
-        source containing null bytes), or is not a single function definition
-        (for example a lambda).
+        builtins, self-referential wrappers, or a corrupted or since-modified
+        source file), cannot be parsed (including source containing null
+        bytes), or is not a single function definition (for example a lambda).
     """
     filename = _filename_of(fn)
     try:
         block_lines, block_start = inspect.getsourcelines(fn)
-    except (OSError, TypeError, ValueError) as exc:
-        message = f"cannot extract source of {_name_of(fn)!r}: {exc}"
+    except (
+        OSError,
+        TypeError,
+        ValueError,
+        SyntaxError,
+        tokenize.TokenError,
+    ) as exc:
+        # inspect.getsourcelines tokenizes the file, so a corrupted or
+        # since-modified source (for example an unterminated triple-quoted
+        # string) can surface a raw tokenize.TokenError or SyntaxError from
+        # retrieval, before block_start is known. No reliable file location
+        # exists at this point, so the diagnostic carries none.
+        reason = _retrieval_reason(exc)
+        message = f"cannot extract source of {_name_of(fn)!r}: {reason}"
         raise SourceExtractionError(
             message,
             diagnostics=[_error(message, filename)],

--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -6,10 +6,10 @@ summary: >-
   decorators. The source text is never modified: an indented definition (a
   nested function or a method) is parsed inside a synthetic "if True:" wrapper
   instead of being dedented, which preserves string literal content and keeps
-  every node's line and column pointing into the real file. A retrieved source
-  that is not a single function definition raises SourceExtractionError
-  carrying structured diagnostics; validating the parsed body against the
-  supported Python subset is a later stage and is not done here.
+  every node's line and column pointing into the real file. Every failure
+  raises SourceExtractionError carrying structured diagnostics; validating the
+  parsed body against the supported Python subset is a later stage and is not
+  done here.
 """
 
 from __future__ import annotations
@@ -44,7 +44,12 @@ def _filename_of(fn: PyFunc) -> str:
     returns:
       type: str
     """
-    fn = inspect.unwrap(fn)
+    try:
+        fn = inspect.unwrap(fn)
+    except ValueError:
+        # A __wrapped__ cycle: attribute the wrapper itself and let the
+        # source retrieval report the cycle.
+        pass
     code = getattr(fn, "__code__", None)
     filename = getattr(code, "co_filename", None)
     return filename or "<unknown>"
@@ -145,11 +150,20 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
       type: ExtractedSource
     raises:
       SourceExtractionError: >-
-        If the retrieved source is not a single function definition (for
-        example a lambda).
+        If the source cannot be retrieved (REPL- or exec-defined functions, C
+        builtins, self-referential wrappers), cannot be parsed, or is not a
+        single function definition (for example a lambda).
     """
     filename = _filename_of(fn)
-    block_lines, block_start = inspect.getsourcelines(fn)
+    try:
+        block_lines, block_start = inspect.getsourcelines(fn)
+    except (OSError, TypeError, ValueError) as exc:
+        message = f"cannot extract source of {_name_of(fn)!r}: {exc}"
+        raise SourceExtractionError(
+            message,
+            diagnostics=[_error(message, filename)],
+        ) from exc
+
     block = "".join(block_lines)
     indented = block_lines[0] != block_lines[0].lstrip()
 
@@ -159,7 +173,22 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
     else:
         text = block
         line_delta = block_start - 1
-    module = ast.parse(text, filename=filename)
+    try:
+        module = ast.parse(text, filename=filename)
+    except SyntaxError as exc:
+        message = f"cannot parse source of {_name_of(fn)!r}: {exc.msg}"
+        line = None
+        if exc.lineno is not None:
+            line = exc.lineno + line_delta
+        # SyntaxError.offset is already a one-based character column and,
+        # because the text is parsed with its original indentation, it
+        # points into the real file line; a zero (no usable column) is
+        # normalized to None.
+        column = exc.offset or None
+        raise SourceExtractionError(
+            message,
+            diagnostics=[_error(message, filename, line, column)],
+        ) from exc
     if indented:
         body = cast("ast.If", module.body[0]).body
     else:

--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -67,6 +67,36 @@ def _name_of(fn: PyFunc) -> str:
     return cast(str, getattr(fn, "__qualname__", repr(fn)))
 
 
+def _column_of(exc: SyntaxError, text: str) -> int | None:
+    """
+    title: Return the validated one-based column of a syntax error.
+    summary: >-
+      SyntaxError.offset is a one-based character column, but it does not
+      always point into the parsed source: for malformed f-string replacement
+      fields, Python 3.10 and 3.11 report an offset into a synthetic string
+      built from the replacement expression. The offset is therefore only
+      trusted when the error's reported text matches the parsed line it claims
+      to come from; otherwise, and when there is no usable offset at all, None
+      is returned.
+    parameters:
+      exc:
+        type: SyntaxError
+      text:
+        type: str
+        description: The exact text that was passed to ast.parse.
+    returns:
+      type: int | None
+    """
+    if not exc.offset or exc.lineno is None or exc.text is None:
+        return None
+    lines = text.splitlines()
+    if not 1 <= exc.lineno <= len(lines):
+        return None
+    if exc.text.rstrip("\r\n") != lines[exc.lineno - 1]:
+        return None
+    return exc.offset
+
+
 def _error(
     message: str,
     filename: str,
@@ -94,6 +124,59 @@ def _error(
         line=line,
         column=column,
     )
+
+
+def _parse_block(
+    fn: PyFunc,
+    text: str,
+    filename: str,
+    line_delta: int,
+) -> ast.Module:
+    """
+    title: Parse source text, translating parse failures.
+    summary: >-
+      Wraps ast.parse so that every parse failure becomes a
+      SourceExtractionError with a located diagnostic. SyntaxError locations
+      are shifted by line_delta to point at the real file line; the column is
+      only kept when _column_of can validate it. Python 3.10 raises ValueError
+      instead of SyntaxError for source containing a null byte, which carries
+      no location attributes at all.
+    parameters:
+      fn:
+        type: PyFunc
+        description: The function being extracted, used for the message.
+      text:
+        type: str
+        description: The exact text to parse.
+      filename:
+        type: str
+      line_delta:
+        type: int
+        description: Shift from text line numbers to real file lines.
+    returns:
+      type: ast.Module
+    """
+    try:
+        return ast.parse(text, filename=filename)
+    except SyntaxError as exc:
+        message = f"cannot parse source of {_name_of(fn)!r}: {exc.msg}"
+        line = None
+        if exc.lineno is not None:
+            line = exc.lineno + line_delta
+        # The text is parsed with its original indentation, so a trusted
+        # offset points into the real file line; _column_of rejects
+        # offsets that do not (for example synthetic f-string locations).
+        column = _column_of(exc, text)
+        raise SourceExtractionError(
+            message,
+            diagnostics=[_error(message, filename, line, column)],
+        ) from exc
+    except ValueError as exc:
+        message = f"cannot parse source of {_name_of(fn)!r}: {exc}"
+        raise SourceExtractionError(
+            message,
+            diagnostics=[_error(message, filename)],
+        ) from exc
 
 
 @dataclass(frozen=True)
@@ -151,8 +234,9 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
     raises:
       SourceExtractionError: >-
         If the source cannot be retrieved (REPL- or exec-defined functions, C
-        builtins, self-referential wrappers), cannot be parsed, or is not a
-        single function definition (for example a lambda).
+        builtins, self-referential wrappers), cannot be parsed (including
+        source containing null bytes), or is not a single function definition
+        (for example a lambda).
     """
     filename = _filename_of(fn)
     try:
@@ -173,22 +257,7 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
     else:
         text = block
         line_delta = block_start - 1
-    try:
-        module = ast.parse(text, filename=filename)
-    except SyntaxError as exc:
-        message = f"cannot parse source of {_name_of(fn)!r}: {exc.msg}"
-        line = None
-        if exc.lineno is not None:
-            line = exc.lineno + line_delta
-        # SyntaxError.offset is already a one-based character column and,
-        # because the text is parsed with its original indentation, it
-        # points into the real file line; a zero (no usable column) is
-        # normalized to None.
-        column = exc.offset or None
-        raise SourceExtractionError(
-            message,
-            diagnostics=[_error(message, filename, line, column)],
-        ) from exc
+    module = _parse_block(fn, text, filename, line_delta)
     if indented:
         body = cast("ast.If", module.body[0]).body
     else:

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -5,8 +5,12 @@ title: Tests for source extraction.
 import ast
 import dataclasses
 import functools
+import importlib.util
 import inspect
+import linecache
+import pathlib
 import sys
+import tokenize
 
 from typing import Any, Callable
 
@@ -16,7 +20,12 @@ import pytest
 from arxjit.core import JitFunction, jit
 from arxjit.diagnostics import DiagnosticSeverity
 from arxjit.errors import SourceExtractionError
-from arxjit.source import ExtractedSource, _column_of, extract_source
+from arxjit.source import (
+    ExtractedSource,
+    _column_of,
+    _retrieval_reason,
+    extract_source,
+)
 
 PyFunc = Callable[..., Any]
 
@@ -544,6 +553,135 @@ def test_malformed_fstring_column_is_validated(
         assert diagnostic.column is None or diagnostic.column <= len(
             'x = f"prefix {a b}"'
         )
+
+
+def test_corrupted_source_file_is_rejected(
+    tmp_path: pathlib.Path,
+) -> None:
+    """
+    title: A file corrupted after import raises SourceExtractionError.
+    summary: >-
+      inspect.getsourcelines tokenizes the file, so a source that becomes
+      unparseable after import (here an unterminated triple-quoted string)
+      makes retrieval raise a raw tokenize.TokenError. It must be translated
+      like every other extraction failure, with no misleading location.
+    parameters:
+      tmp_path:
+        type: pathlib.Path
+    """
+    module_path = tmp_path / "corrupt_after_import.py"
+    module_path.write_text("def valid_fn(x):\n    return x + 1\n")
+    spec = importlib.util.spec_from_file_location(
+        "corrupt_after_import", module_path
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    with module_path.open("a") as stream:
+        stream.write('    y = """unterminated\n')
+    linecache.clearcache()
+
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(module.valid_fn)
+    assert isinstance(
+        caught.value.__cause__, (tokenize.TokenError, SyntaxError)
+    )
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.message.startswith("cannot extract source of")
+    assert diagnostic.line is None
+    assert diagnostic.column is None
+
+
+def test_retrieval_token_error_is_translated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: A TokenError from retrieval becomes SourceExtractionError.
+    summary: >-
+      The diagnostic uses the tokenizer's own message rather than its raw
+      (message, position) args tuple, and attaches no file location because
+      retrieval fails before the block's start line is known.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def fake_getsourcelines(fn: Any) -> tuple[list[str], int]:
+        """
+        title: Raise a TokenError like a truncated multi-line string.
+        parameters:
+          fn:
+            type: Any
+        returns:
+          type: tuple[list[str], int]
+        """
+        raise tokenize.TokenError("EOF in multi-line string", (3, 8))
+
+    monkeypatch.setattr(inspect, "getsourcelines", fake_getsourcelines)
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_add)
+    assert isinstance(caught.value.__cause__, tokenize.TokenError)
+    (diagnostic,) = caught.value.diagnostics
+    assert "EOF in multi-line string" in diagnostic.message
+    assert "(3, 8)" not in diagnostic.message
+    assert diagnostic.line is None
+    assert diagnostic.column is None
+
+
+def test_retrieval_syntax_error_is_translated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: A SyntaxError from retrieval becomes SourceExtractionError.
+    summary: >-
+      inspect.getblock can re-raise a SyntaxError during retrieval; unlike a
+      parse-time SyntaxError it arrives before the block's start line is known,
+      so no file location is attached, and the message drops the block-relative
+      position that str(SyntaxError) would otherwise embed.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def fake_getsourcelines(fn: Any) -> tuple[list[str], int]:
+        """
+        title: Raise a located SyntaxError like a retrieval failure.
+        parameters:
+          fn:
+            type: Any
+        returns:
+          type: tuple[list[str], int]
+        """
+        raise SyntaxError("bad token", ("<unknown>", 3, 5, "    bad\n"))
+
+    monkeypatch.setattr(inspect, "getsourcelines", fake_getsourcelines)
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_add)
+    assert isinstance(caught.value.__cause__, SyntaxError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.message.startswith("cannot extract source of")
+    assert diagnostic.message.endswith("bad token")
+    assert "line 3" not in diagnostic.message
+    assert diagnostic.line is None
+    assert diagnostic.column is None
+
+
+def test_retrieval_reason_strips_embedded_locations() -> None:
+    """
+    title: The retrieval-reason helper keeps only the human message.
+    summary: >-
+      Exercises each branch directly: a TokenError's (message, position) tuple
+      reduces to its message, a SyntaxError drops its location suffix, and any
+      other exception falls back to str().
+    """
+    token_error = tokenize.TokenError("EOF in multi-line string", (3, 8))
+    assert _retrieval_reason(token_error) == "EOF in multi-line string"
+
+    syntax_error = SyntaxError("bad token", ("<unknown>", 3, 5, "    bad\n"))
+    assert _retrieval_reason(syntax_error) == "bad token"
+
+    assert _retrieval_reason(OSError("no source")) == "no source"
 
 
 def test_parse_valueerror_is_translated(

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -6,6 +6,7 @@ import ast
 import dataclasses
 import functools
 import inspect
+import sys
 
 from typing import Any, Callable
 
@@ -15,7 +16,7 @@ import pytest
 from arxjit.core import JitFunction, jit
 from arxjit.diagnostics import DiagnosticSeverity
 from arxjit.errors import SourceExtractionError
-from arxjit.source import ExtractedSource, extract_source
+from arxjit.source import ExtractedSource, _column_of, extract_source
 
 PyFunc = Callable[..., Any]
 
@@ -464,6 +465,165 @@ def test_indented_unparsable_source_maps_to_file_lines(
     assert isinstance(caught.value.__cause__, SyntaxError)
     (diagnostic,) = caught.value.diagnostics
     assert diagnostic.line == 10
+
+
+def test_null_byte_source_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: Source containing a null byte raises SourceExtractionError.
+    summary: >-
+      Python 3.10 raises ValueError (not SyntaxError) from ast.parse for source
+      containing null bytes; later versions raise SyntaxError. Either way the
+      failure must be translated, never leaked raw.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def fake_getsourcelines(fn: Any) -> tuple[list[str], int]:
+        """
+        title: Return a source block containing a null byte.
+        parameters:
+          fn:
+            type: Any
+        returns:
+          type: tuple[list[str], int]
+        """
+        return (["def broken():\n", "    return '\0'\n"], 3)
+
+    monkeypatch.setattr(inspect, "getsourcelines", fake_getsourcelines)
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_add)
+    assert isinstance(caught.value.__cause__, (ValueError, SyntaxError))
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.message.startswith("cannot parse source of")
+    assert "null byte" in diagnostic.message
+
+
+def test_malformed_fstring_column_is_validated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: A malformed f-string never yields a misleading column.
+    summary: >-
+      On Python 3.10 and 3.11 the parser reports f-string errors against a
+      synthetic string built from the replacement expression, so the offset
+      does not point into the real source line and the diagnostic column must
+      fall back to None; newer versions report real file locations and keep a
+      column.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def fake_getsourcelines(fn: Any) -> tuple[list[str], int]:
+        """
+        title: Return a source block with a malformed f-string.
+        parameters:
+          fn:
+            type: Any
+        returns:
+          type: tuple[list[str], int]
+        """
+        return (['x = f"prefix {a b}"\n'], 5)
+
+    monkeypatch.setattr(inspect, "getsourcelines", fake_getsourcelines)
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_add)
+    assert isinstance(caught.value.__cause__, SyntaxError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.line == 5
+    if sys.version_info < (3, 12):
+        assert diagnostic.column is None
+    elif sys.version_info >= (3, 13):
+        assert diagnostic.column is not None
+    else:
+        # 3.12 straddles the PEP 701 transition; either a validated
+        # column or the None fallback is acceptable, never a bogus one.
+        assert diagnostic.column is None or diagnostic.column <= len(
+            'x = f"prefix {a b}"'
+        )
+
+
+def test_parse_valueerror_is_translated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: A ValueError from ast.parse becomes SourceExtractionError.
+    summary: >-
+      Only Python 3.10 raises ValueError from ast.parse in practice (null
+      bytes), so the translation is exercised deterministically on every
+      version by stubbing the parser.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def fake_parse(*_args: Any, **_kwargs: Any) -> Any:
+        """
+        title: Raise ValueError like ast.parse on a null byte.
+        parameters:
+          _args:
+            type: Any
+            variadic: positional
+          _kwargs:
+            type: Any
+            variadic: keyword
+        returns:
+          type: Any
+        """
+        raise ValueError("source code string cannot contain null bytes")
+
+    monkeypatch.setattr(ast, "parse", fake_parse)
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_add)
+    assert isinstance(caught.value.__cause__, ValueError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.message.startswith("cannot parse source of")
+    assert diagnostic.line is None
+    assert diagnostic.column is None
+
+
+def test_column_validation_of_syntax_errors() -> None:
+    """
+    title: The column validator trusts only offsets that match the text.
+    summary: >-
+      Exercises every rejection branch directly with synthetic SyntaxError
+      instances, so the behavior is identical on all Python versions regardless
+      of which parser errors each version produces.
+    """
+    text = "x = 1\n"
+
+    def syntax_error(
+        lineno: int | None,
+        offset: int | None,
+        error_text: str | None,
+    ) -> SyntaxError:
+        """
+        title: Build a SyntaxError with the given location attributes.
+        parameters:
+          lineno:
+            type: int | None
+          offset:
+            type: int | None
+          error_text:
+            type: str | None
+        returns:
+          type: SyntaxError
+        """
+        exc = SyntaxError("boom")
+        exc.lineno = lineno
+        exc.offset = offset
+        exc.text = error_text
+        return exc
+
+    assert _column_of(syntax_error(1, 5, "x = 1\n"), text) == 5
+    assert _column_of(syntax_error(1, 0, "x = 1\n"), text) is None
+    assert _column_of(syntax_error(None, 5, "x = 1\n"), text) is None
+    assert _column_of(syntax_error(1, 5, None), text) is None
+    assert _column_of(syntax_error(99, 5, "x = 1\n"), text) is None
+    assert _column_of(syntax_error(1, 2, "(a b)\n"), text) is None
 
 
 def test_extracted_source_is_frozen() -> None:

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -5,6 +5,7 @@ title: Tests for source extraction.
 import ast
 import dataclasses
 import functools
+import inspect
 
 from typing import Any, Callable
 
@@ -347,6 +348,122 @@ def test_lambda_is_rejected() -> None:
     assert diagnostic.severity is DiagnosticSeverity.ERROR
     assert diagnostic.filename == __file__
     assert diagnostic.line is not None
+
+
+def test_builtin_is_rejected() -> None:
+    """
+    title: A C builtin has no source and raises SourceExtractionError.
+    """
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(len)
+    assert isinstance(caught.value.__cause__, TypeError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.filename == "<unknown>"
+    assert "cannot extract source of 'len'" in diagnostic.message
+
+
+def test_exec_defined_function_is_rejected() -> None:
+    """
+    title: An exec-defined function raises SourceExtractionError.
+    """
+    namespace: dict[str, Any] = {}
+    exec(
+        compile("def made(x):\n    return x\n", "<string>", "exec"),
+        namespace,
+    )
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(namespace["made"])
+    assert isinstance(caught.value.__cause__, OSError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.filename == "<string>"
+    assert diagnostic.line is None
+
+
+def test_self_wrapped_function_is_rejected() -> None:
+    """
+    title: A __wrapped__ cycle raises SourceExtractionError, not ValueError.
+    """
+
+    def looped(x: int) -> int:
+        """
+        title: Return the argument.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x
+
+    looped.__wrapped__ = looped  # type: ignore[attr-defined]
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(looped)
+    assert isinstance(caught.value.__cause__, ValueError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.filename == __file__
+
+
+def test_unparsable_source_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: A source block that fails ast.parse raises with a location.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def fake_getsourcelines(fn: Any) -> tuple[list[str], int]:
+        """
+        title: Return a syntactically broken source block.
+        parameters:
+          fn:
+            type: Any
+        returns:
+          type: tuple[list[str], int]
+        """
+        return (["def broken(:\n"], 7)
+
+    monkeypatch.setattr(inspect, "getsourcelines", fake_getsourcelines)
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_add)
+    assert isinstance(caught.value.__cause__, SyntaxError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.message.startswith("cannot parse source of")
+    assert diagnostic.line == 7
+
+
+def test_indented_unparsable_source_maps_to_file_lines(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: A broken indented block reports the file line, not the wrapped one.
+    summary: >-
+      An indented block is parsed inside the synthetic wrapper, which shifts
+      SyntaxError line numbers by one; the diagnostic must still point at the
+      real file line.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def fake_getsourcelines(fn: Any) -> tuple[list[str], int]:
+        """
+        title: Return a broken source block indented like a method.
+        parameters:
+          fn:
+            type: Any
+        returns:
+          type: tuple[list[str], int]
+        """
+        return (["    def broken(:\n"], 10)
+
+    monkeypatch.setattr(inspect, "getsourcelines", fake_getsourcelines)
+    with pytest.raises(SourceExtractionError) as caught:
+        extract_source(sample_add)
+    assert isinstance(caught.value.__cause__, SyntaxError)
+    (diagnostic,) = caught.value.diagnostics
+    assert diagnostic.line == 10
 
 
 def test_extracted_source_is_frozen() -> None:


### PR DESCRIPTION
## Summary

Sprint 2, source extraction part 2 — the follow-up promised in #96, completing the last bullet of wiki "Proposed Issue 3":

- [x] Provide clear errors when source extraction is unavailable.

With this PR, **every** extraction failure raises `SourceExtractionError` carrying one located, structured `Diagnostic` (contract from #95) instead of leaking a raw stdlib exception:

| failure | previously | now |
|---|---|---|
| exec-/REPL-defined function (`OSError`) | raw `OSError` | `SourceExtractionError`, filename from `co_filename` (e.g. `"<string>"`) |
| C builtin, no code object (`TypeError`) | raw `TypeError` | `SourceExtractionError`, filename `"<unknown>"` |
| self-referential `__wrapped__` cycle (`ValueError`) | raw `ValueError` | `SourceExtractionError`; filename attribution falls back to the wrapper's own file |
| block that fails `ast.parse` (`SyntaxError`) | raw `SyntaxError` | `SourceExtractionError` with the error mapped to the **real file line** and column |
| not a single function definition (e.g. lambda) | already `SourceExtractionError` (#96) | unchanged |

## Details worth reviewing

- **SyntaxError location mapping goes through the synthetic wrapper.** #96 parses indented definitions inside `"if True:\n" + block`, which shifts `SyntaxError.lineno` by one relative to the block; the translation uses the same `line_delta` as the success path, so the diagnostic points at the real file line either way. There's a dedicated test for the indented case (`test_indented_unparsable_source_maps_to_file_lines`).
- **Column contract:** `SyntaxError.offset` is already a one-based character column (probed on CPython 3.10/3.11/3.13/3.14), and since #96 parses the text with its original indentation it points into the real file line — so it's stored directly, satisfying the `Diagnostic.column` contract from #95. A zero offset (no usable column) is normalized to `None`.
- **`__wrapped__` cycles:** `inspect.unwrap` inside `_filename_of` can raise `ValueError` on a self-referential wrapper; it now falls back to attributing the wrapper's own file and lets the source retrieval report the cycle, which is then translated like the other retrieval failures — so the documented "failures raise `SourceExtractionError`" contract has no gaps.
- Original exceptions are kept as `__cause__` (`raise ... from exc`) for debugging.

## Verification

- 5 new tests (52 total: builtin, exec-defined, `__wrapped__` cycle, unparsable block, unparsable *indented* block), arxjit coverage 100%.
- All gates green locally: pytest + the 86% coverage gate, ruff format/check, mypy strict, bandit, vulture, mccabe, and `douki sync` idempotent.

Refs: #96 (extraction pipeline), #95 (diagnostics/error layer). The normalized-source follow-up remains tracked in #97.
