### PR TITLE
feat(arxjit): add Python-subset validation for decorated functions

### DIFF
--- a/packages/arxjit/pyproject.toml
+++ b/packages/arxjit/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10,<4"
 dependencies = [
   "astx == 1.23.1",  # semantic-release
   "pyirx == 1.23.1",  # semantic-release
+  "plum-dispatch >= 2",
 ]
 
 [build-system]

--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -21,6 +21,7 @@ from arxjit.types import (
     i32,
     i64,
 )
+from arxjit.validation import validate
 
 _DISTRIBUTION_NAME = "arxjit"
 
@@ -60,4 +61,5 @@ __all__ = [
     "i32",
     "i64",
     "jit",
+    "validate",
 ]

--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -89,6 +89,24 @@ def _globals_of(fn: PyFunc) -> Mapping[str, Any] | None:
     return cast("Mapping[str, Any] | None", namespace)
 
 
+def _freevars_of(fn: PyFunc) -> frozenset[str]:
+    """
+    title: Return the names a function captures from enclosing scopes.
+    summary: >-
+      Carried through extraction for the same reason as the module namespace: a
+      name the compiler treats as a builtin may instead be a closure capture,
+      which the extracted AST cannot distinguish from the builtin. Empty for a
+      function that captures nothing and for objects without a code object.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: frozenset[str]
+    """
+    code = getattr(_unwrapped(fn), "__code__", None)
+    return frozenset(getattr(code, "co_freevars", ()) or ())
+
+
 def _name_of(fn: PyFunc) -> str:
     """
     title: Return a human-readable name for a function.
@@ -271,6 +289,12 @@ class ExtractedSource:
           level shadowing of a name the compiler treats as a builtin, which the
           AST alone cannot reveal. Excluded from repr and equality: it is
           incidental runtime context, not part of the extracted source.
+      freevars:
+        type: frozenset[str]
+        description: >-
+          The names the function captures from enclosing scopes, empty when it
+          captures nothing. Carried for the same reason as ``globalns``: a
+          captured name is indistinguishable from a builtin in the AST alone.
     """
 
     filename: str
@@ -280,6 +304,7 @@ class ExtractedSource:
     globalns: Mapping[str, Any] | None = field(
         default=None, repr=False, compare=False
     )
+    freevars: frozenset[str] = frozenset()
 
 
 def extract_source(fn: PyFunc) -> ExtractedSource:
@@ -364,6 +389,7 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
         lineno=def_lineno,
         node=node,
         globalns=_globals_of(fn),
+        freevars=_freevars_of(fn),
     )
 
 

--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -18,7 +18,8 @@ import ast
 import inspect
 import tokenize
 
-from dataclasses import dataclass
+from collections.abc import Mapping
+from dataclasses import dataclass, field
 from typing import Any, Callable, cast
 
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
@@ -30,30 +31,62 @@ _WRAPPER = "if True:\n"
 _WRAPPER_LINES = 1
 
 
+def _unwrapped(fn: PyFunc) -> PyFunc:
+    """
+    title: Follow __wrapped__ chains to the underlying function.
+    summary: >-
+      inspect.getsourcelines unwraps before reading source, so anything derived
+      from the function (its filename, its globals) must unwrap too or it would
+      describe a different function than the retrieved source. A __wrapped__
+      cycle yields the wrapper itself, leaving the source retrieval to report
+      the cycle.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: PyFunc
+    """
+    try:
+        return cast(PyFunc, inspect.unwrap(fn))
+    except ValueError:
+        return fn
+
+
 def _filename_of(fn: PyFunc) -> str:
     """
     title: Return the filename a function was defined in.
     summary: >-
-      Follows __wrapped__ chains first, because inspect.getsourcelines does the
-      same and the filename must match the source it returns; a JitFunction
-      wrapper is therefore attributed to the file of the function it wraps.
-      Reads the unwrapped function's code object; falls back to "<unknown>" for
-      objects without one (for example C builtins).
+      Reads the unwrapped function's code object, so a JitFunction wrapper is
+      attributed to the file of the function it wraps; falls back to
+      "<unknown>" for objects without one (for example C builtins).
     parameters:
       fn:
         type: PyFunc
     returns:
       type: str
     """
-    try:
-        fn = inspect.unwrap(fn)
-    except ValueError:
-        # A __wrapped__ cycle: attribute the wrapper itself and let the
-        # source retrieval report the cycle.
-        pass
-    code = getattr(fn, "__code__", None)
+    code = getattr(_unwrapped(fn), "__code__", None)
     filename = getattr(code, "co_filename", None)
     return filename or "<unknown>"
+
+
+def _globals_of(fn: PyFunc) -> Mapping[str, Any] | None:
+    """
+    title: Return the module namespace a function was defined in.
+    summary: >-
+      Carried through extraction so later stages can tell whether a name the
+      compiler treats as a builtin (currently only range) is shadowed at module
+      level, which no amount of AST inspection can reveal. Reads the unwrapped
+      function so it matches the retrieved source; None when the object has no
+      globals (for example a C builtin).
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: Mapping[str, Any] | None
+    """
+    namespace = getattr(_unwrapped(fn), "__globals__", None)
+    return cast("Mapping[str, Any] | None", namespace)
 
 
 def _name_of(fn: PyFunc) -> str:
@@ -230,12 +263,23 @@ class ExtractedSource:
           the source is parsed without modifying its indentation; only the
           byte-to-character conversion is needed at the boundary that produces
           a diagnostic.
+      globalns:
+        type: Mapping[str, Any] | None
+        description: >-
+          The module namespace the function was defined in, or None when the
+          object has no globals. Carried so later stages can detect module-
+          level shadowing of a name the compiler treats as a builtin, which the
+          AST alone cannot reveal. Excluded from repr and equality: it is
+          incidental runtime context, not part of the extracted source.
     """
 
     filename: str
     source: str
     lineno: int
     node: ast.FunctionDef | ast.AsyncFunctionDef
+    globalns: Mapping[str, Any] | None = field(
+        default=None, repr=False, compare=False
+    )
 
 
 def extract_source(fn: PyFunc) -> ExtractedSource:
@@ -319,6 +363,7 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
         source=source,
         lineno=def_lineno,
         node=node,
+        globalns=_globals_of(fn),
     )
 
 

--- a/packages/arxjit/src/arxjit/validation.py
+++ b/packages/arxjit/src/arxjit/validation.py
@@ -1,0 +1,537 @@
+"""
+title: Python-subset validation for arxjit.
+summary: >-
+  Second stage of the arxjit pipeline: walk the ast node produced by
+  arxjit.source and check it only uses the v1 supported subset of pure Python
+  (typed scalar arguments, arithmetic/comparison/boolean expressions, local
+  assignments, if/while, for over range, return). Every rejected construct is
+  collected into its own Diagnostic so a function using several unsupported
+  constructs reports all of them at once via UnsupportedSyntaxError; lowering
+  the accepted subset to astx is a later stage and is not done here.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from typing import cast
+
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.errors import UnsupportedSyntaxError
+from arxjit.source import ExtractedSource
+
+_ALLOWED_BINOPS: tuple[type[ast.operator], ...] = (
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.FloorDiv,
+    ast.Mod,
+    ast.Pow,
+)
+_ALLOWED_UNARYOPS: tuple[type[ast.unaryop], ...] = (
+    ast.UAdd,
+    ast.USub,
+    ast.Not,
+)
+_ALLOWED_BOOLOPS: tuple[type[ast.boolop], ...] = (ast.And, ast.Or)
+_ALLOWED_COMPAREOPS: tuple[type[ast.cmpop], ...] = (
+    ast.Eq,
+    ast.NotEq,
+    ast.Lt,
+    ast.LtE,
+    ast.Gt,
+    ast.GtE,
+)
+
+_UNSUPPORTED_MESSAGES: dict[type[ast.AST], str] = {
+    ast.ClassDef: "class definitions are not supported",
+    ast.Lambda: "lambda expressions are not supported",
+    ast.FunctionDef: (
+        "nested function definitions (closures) are not supported"
+    ),
+    ast.AsyncFunctionDef: "async function definitions are not supported",
+    ast.AsyncFor: "async for loops are not supported",
+    ast.AsyncWith: "with statements are not supported",
+    ast.With: "with statements are not supported",
+    ast.Try: "try/except is not supported",
+    ast.Raise: "raise statements are not supported",
+    ast.Assert: "assert statements are not supported",
+    ast.Import: "import statements are not supported",
+    ast.ImportFrom: "import statements are not supported",
+    ast.Global: "global declarations are not supported",
+    ast.Nonlocal: "nonlocal declarations are not supported",
+    ast.Yield: "generators (yield) are not supported",
+    ast.YieldFrom: "generators (yield) are not supported",
+    ast.Await: "await expressions are not supported",
+    ast.List: "list literals are not supported",
+    ast.Dict: "dict literals are not supported",
+    ast.Set: "set literals are not supported",
+    ast.Tuple: "tuple literals are not supported",
+    ast.ListComp: "comprehensions are not supported",
+    ast.DictComp: "comprehensions are not supported",
+    ast.SetComp: "comprehensions are not supported",
+    ast.GeneratorExp: "generator expressions are not supported",
+    ast.Delete: "del statements are not supported",
+    ast.AnnAssign: "annotated assignments are not supported",
+    ast.AugAssign: "augmented assignment (e.g. +=) is not supported",
+    ast.JoinedStr: "f-strings are not supported",
+    ast.NamedExpr: "walrus assignment expressions are not supported",
+    ast.Starred: "starred expressions are not supported",
+    ast.Attribute: "attribute access is not supported",
+    ast.Subscript: "subscripting is not supported",
+    ast.Slice: "slicing is not supported",
+    ast.Match: "match statements are not supported",
+}
+# TryStar (except*) was added in Python 3.11; guard the reference so this
+# module still imports cleanly on 3.10.
+if (_try_star := getattr(ast, "TryStar", None)) is not None:
+    _UNSUPPORTED_MESSAGES[_try_star] = "try/except* is not supported"
+
+
+def _is_range_call(node: ast.expr) -> bool:
+    """
+    title: Return whether a node is a call to the builtin range().
+    summary: >-
+      Only the exact shape range(...) with no keyword arguments is accepted;
+      range is looked up by name only, so a shadowed or attribute-qualified
+      "range" is rejected like any other call.
+    parameters:
+      node:
+        type: ast.expr
+    returns:
+      type: bool
+    """
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "range"
+        and not node.keywords
+    )
+
+
+def _char_column(line: str, byte_offset: int) -> int:
+    """
+    title: Convert a zero-based UTF-8 byte offset to a one-based column.
+    summary: >-
+      ast column offsets are zero-based UTF-8 byte offsets into their source
+      line, but Diagnostic.column is documented as a one-based Unicode
+      character column. Decoding the byte prefix back to text and measuring its
+      length performs the conversion exactly, including when multi-byte
+      characters appear before the target column.
+    parameters:
+      line:
+        type: str
+        description: The real source line the offset was reported against.
+      byte_offset:
+        type: int
+    returns:
+      type: int
+    """
+    prefix = line.encode("utf-8")[:byte_offset]
+    return len(prefix.decode("utf-8", errors="replace")) + 1
+
+
+def _diagnostic(
+    extracted: ExtractedSource,
+    node: ast.AST,
+    message: str,
+) -> Diagnostic:
+    """
+    title: Build an ERROR diagnostic located at an ast node.
+    summary: >-
+      Reads the node's lineno/col_offset when present and converts the column
+      to the one-based character contract via _char_column; falls back to no
+      location when the node carries none (rare for real parsed nodes, but kept
+      safe for synthetic ones). node.lineno is a real file line number
+      (extract_source already shifted it), while extracted.source is indexed
+      from its own first line, so the node's line is looked up at
+      extracted.source.splitlines()[lineno - extracted.lineno] rather than
+      lineno - 1.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      node:
+        type: ast.AST
+      message:
+        type: str
+    returns:
+      type: Diagnostic
+    """
+    lineno = getattr(node, "lineno", None)
+    col_offset = getattr(node, "col_offset", None)
+    column = None
+    if lineno is not None and col_offset is not None:
+        lines = extracted.source.splitlines()
+        index = lineno - extracted.lineno
+        if 0 <= index < len(lines):
+            column = _char_column(lines[index], col_offset)
+    return Diagnostic(
+        severity=DiagnosticSeverity.ERROR,
+        message=message,
+        filename=extracted.filename,
+        line=lineno,
+        column=column,
+    )
+
+
+class _SubsetValidator(ast.NodeVisitor):
+    """
+    title: Collect one diagnostic per Python construct outside the v1 subset.
+    summary: >-
+      A rejected node's children are not descended into, so a single bad
+      expression tree reports one diagnostic rather than one per nested node;
+      independent sibling statements (including inside if/while/for bodies) are
+      still each visited and validated in full.
+    attributes:
+      extracted:
+        description: The extracted source being validated.
+      diagnostics:
+        type: list[Diagnostic]
+        description: One entry per rejected construct.
+    """
+
+    def __init__(self, extracted: ExtractedSource) -> None:
+        """
+        title: Initialize the validator for one function's source.
+        parameters:
+          extracted:
+            type: ExtractedSource
+        """
+        self.extracted = extracted
+        self.diagnostics: list[Diagnostic] = []
+
+    def _reject(self, node: ast.AST, message: str) -> None:
+        """
+        title: Record a diagnostic for an unsupported node.
+        parameters:
+          node:
+            type: ast.AST
+          message:
+            type: str
+        """
+        self.diagnostics.append(_diagnostic(self.extracted, node, message))
+
+    # -- statements --------------------------------------------------
+
+    def visit_Return(self, node: ast.Return) -> None:
+        """
+        title: Validate a return statement's value, if any.
+        parameters:
+          node:
+            type: ast.Return
+        """
+        if node.value is not None:
+            self.visit(node.value)
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """
+        title: Validate a single-target local variable assignment.
+        parameters:
+          node:
+            type: ast.Assign
+        """
+        if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+            self._reject(
+                node,
+                "only assignment to a single local variable is supported",
+            )
+        self.visit(node.value)
+
+    def visit_If(self, node: ast.If) -> None:
+        """
+        title: Validate an if/else statement and both branches.
+        parameters:
+          node:
+            type: ast.If
+        """
+        self.visit(node.test)
+        for stmt in (*node.body, *node.orelse):
+            self.visit(stmt)
+
+    def visit_While(self, node: ast.While) -> None:
+        """
+        title: Validate a while loop and its body.
+        parameters:
+          node:
+            type: ast.While
+        """
+        self.visit(node.test)
+        for stmt in (*node.body, *node.orelse):
+            self.visit(stmt)
+
+    def visit_For(self, node: ast.For) -> None:
+        """
+        title: Validate a for loop, restricted to iterating over range().
+        parameters:
+          node:
+            type: ast.For
+        """
+        if not isinstance(node.target, ast.Name):
+            self._reject(
+                node.target,
+                "for-loop targets must be a single local variable",
+            )
+        if _is_range_call(node.iter):
+            for arg in cast(ast.Call, node.iter).args:
+                self.visit(arg)
+        else:
+            self._reject(
+                node.iter,
+                "for loops are only supported over range(...)",
+            )
+        for stmt in (*node.body, *node.orelse):
+            self.visit(stmt)
+
+    def visit_Expr(self, node: ast.Expr) -> None:
+        """
+        title: Accept a standalone string literal, reject anything else.
+        summary: >-
+          A bare string statement (a docstring, or a no-op string anywhere in
+          the body) has no compilable effect and is silently allowed. A bare
+          "yield x" is the common generator-function form and is delegated to
+          the generic unsupported-construct lookup so it gets the specific
+          generators message instead of a generic one; any other standalone
+          expression statement computes a value that is immediately discarded
+          and is rejected directly.
+        parameters:
+          node:
+            type: ast.Expr
+        """
+        if isinstance(node.value, ast.Constant) and isinstance(
+            node.value.value, str
+        ):
+            return
+        if isinstance(node.value, (ast.Yield, ast.YieldFrom)):
+            self.visit(node.value)
+            return
+        self._reject(
+            node, "standalone expression statements are not supported"
+        )
+
+    def visit_Pass(self, node: ast.Pass) -> None:
+        """
+        title: Accept a pass statement; it has no effect.
+        parameters:
+          node:
+            type: ast.Pass
+        """
+
+    # -- expressions -------------------------------------------------
+
+    def visit_Name(self, node: ast.Name) -> None:
+        """
+        title: Accept a variable reference.
+        parameters:
+          node:
+            type: ast.Name
+        """
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        """
+        title: Accept only int, float, and bool literals.
+        parameters:
+          node:
+            type: ast.Constant
+        """
+        if isinstance(node.value, (bool, int, float)):
+            return
+        kind = type(node.value).__name__
+        self._reject(node, f"{kind} literals are not supported")
+
+    def visit_BinOp(self, node: ast.BinOp) -> None:
+        """
+        title: Validate an arithmetic binary expression.
+        parameters:
+          node:
+            type: ast.BinOp
+        """
+        if not isinstance(node.op, _ALLOWED_BINOPS):
+            kind = type(node.op).__name__
+            self._reject(node, f"the {kind} operator is not supported")
+        self.visit(node.left)
+        self.visit(node.right)
+
+    def visit_UnaryOp(self, node: ast.UnaryOp) -> None:
+        """
+        title: Validate a unary expression.
+        parameters:
+          node:
+            type: ast.UnaryOp
+        """
+        if not isinstance(node.op, _ALLOWED_UNARYOPS):
+            kind = type(node.op).__name__
+            self._reject(node, f"the {kind} operator is not supported")
+        self.visit(node.operand)
+
+    def visit_BoolOp(self, node: ast.BoolOp) -> None:
+        """
+        title: Validate a boolean and/or expression.
+        parameters:
+          node:
+            type: ast.BoolOp
+        """
+        if not isinstance(node.op, _ALLOWED_BOOLOPS):  # pragma: no cover
+            # And and Or are the only boolean operators, so this guard is
+            # unreachable today; it is kept for parity with the other
+            # operator visitors and to fail closed if Python adds one.
+            kind = type(node.op).__name__
+            self._reject(node, f"the {kind} operator is not supported")
+        for value in node.values:
+            self.visit(value)
+
+    def visit_Compare(self, node: ast.Compare) -> None:
+        """
+        title: Validate a (possibly chained) comparison expression.
+        parameters:
+          node:
+            type: ast.Compare
+        """
+        for op in node.ops:
+            if not isinstance(op, _ALLOWED_COMPAREOPS):
+                kind = type(op).__name__
+                self._reject(node, f"the {kind} comparison is not supported")
+        self.visit(node.left)
+        for comparator in node.comparators:
+            self.visit(comparator)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        """
+        title: Reject a function call.
+        summary: >-
+          Only reachable for calls that are not a for-loop's range(...)
+          iterator, which visit_For special-cases before it ever reaches the
+          generic expression visitor.
+        parameters:
+          node:
+            type: ast.Call
+        """
+        self._reject(
+            node,
+            "calling functions is not supported (only range() in a for loop)",
+        )
+
+    def generic_visit(self, node: ast.AST) -> None:
+        """
+        title: Reject any node with no explicit visit_* handler.
+        summary: >-
+          Every accepted statement and expression kind has its own visit_*
+          method above; reaching this method means the node is either a known-
+          unsupported construct (looked up for a specific message) or one this
+          validator does not recognize at all, which is rejected the same way
+          so new Python syntax fails closed instead of silently passing
+          through.
+        parameters:
+          node:
+            type: ast.AST
+        """
+        message = _UNSUPPORTED_MESSAGES.get(type(node))
+        if message is None:
+            message = f"{type(node).__name__} is not supported"
+        self._reject(node, message)
+
+
+def _validate_arguments(
+    extracted: ExtractedSource,
+    args: ast.arguments,
+) -> list[Diagnostic]:
+    """
+    title: Reject argument shapes outside the v1 subset.
+    summary: >-
+      Rejects *args, **kwargs, keyword-only arguments, and default values; does
+      not check argument or return annotations, which is the reconciliation
+      stage's job once a function has already passed validation.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      args:
+        type: ast.arguments
+    returns:
+      type: list[Diagnostic]
+    """
+    diagnostics: list[Diagnostic] = []
+    if args.vararg is not None:
+        diagnostics.append(
+            _diagnostic(
+                extracted,
+                args.vararg,
+                "variadic positional arguments (*args) are not supported",
+            )
+        )
+    if args.kwarg is not None:
+        diagnostics.append(
+            _diagnostic(
+                extracted,
+                args.kwarg,
+                "variadic keyword arguments (**kwargs) are not supported",
+            )
+        )
+    if args.kwonlyargs:
+        diagnostics.append(
+            _diagnostic(
+                extracted,
+                args.kwonlyargs[0],
+                "keyword-only arguments are not supported",
+            )
+        )
+    default = next(
+        (d for d in (*args.defaults, *args.kw_defaults) if d is not None),
+        None,
+    )
+    if default is not None:
+        diagnostics.append(
+            _diagnostic(
+                extracted,
+                default,
+                "default argument values are not supported",
+            )
+        )
+    return diagnostics
+
+
+def validate(extracted: ExtractedSource) -> None:
+    """
+    title: Validate that a function uses only the supported Python subset.
+    summary: >-
+      Checks the function's argument shape and walks its body, collecting one
+      diagnostic per rejected construct. A function using several unsupported
+      constructs is reported in a single UnsupportedSyntaxError carrying all of
+      them, so a user fixes everything in one pass instead of one error at a
+      time.
+    parameters:
+      extracted:
+        type: ExtractedSource
+        description: The result of arxjit.source.extract_source.
+    raises:
+      UnsupportedSyntaxError: >-
+        If the function is async, has an unsupported argument shape, or its
+        body uses any construct outside the v1 subset.
+    """
+    node = extracted.node
+    diagnostics: list[Diagnostic] = []
+
+    if isinstance(node, ast.AsyncFunctionDef):
+        diagnostics.append(
+            _diagnostic(
+                extracted,
+                node,
+                "async function definitions are not supported",
+            )
+        )
+
+    diagnostics.extend(_validate_arguments(extracted, node.args))
+
+    visitor = _SubsetValidator(extracted)
+    for stmt in node.body:
+        visitor.visit(stmt)
+    diagnostics.extend(visitor.diagnostics)
+
+    if diagnostics:
+        raise UnsupportedSyntaxError(
+            f"{node.name!r} uses Python constructs outside the"
+            " supported subset",
+            diagnostics=diagnostics,
+        )
+
+
+__all__ = ["validate"]

--- a/packages/arxjit/src/arxjit/validation.py
+++ b/packages/arxjit/src/arxjit/validation.py
@@ -1,24 +1,29 @@
+# mypy: disable-error-code=no-redef
 """
 title: Python-subset validation for arxjit.
 summary: >-
   Second stage of the arxjit pipeline: walk the ast node produced by
   arxjit.source and check it only uses the v1 supported subset of pure Python
-  (typed scalar arguments, arithmetic/comparison/boolean expressions, local
-  assignments, if/while, for over range, return). Every rejected construct is
-  collected into its own Diagnostic so a function using several unsupported
-  constructs reports all of them at once via UnsupportedSyntaxError; lowering
-  the accepted subset to astx is a later stage and is not done here.
+  (typed scalar arguments, arithmetic/comparison/boolean expressions, single-
+  target local assignments, if/else, while, for over range, return). Dispatch
+  is by node type via plum, matching the visitor convention used across the Arx
+  packages. Every rejected construct is collected into its own Diagnostic so a
+  function using several unsupported constructs reports all of them at once via
+  UnsupportedSyntaxError; lowering the accepted subset to astx is a later stage
+  and is not done here.
 """
 
 from __future__ import annotations
 
 import ast
 
-from typing import cast
+from plum import dispatch
 
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
 from arxjit.errors import UnsupportedSyntaxError
 from arxjit.source import ExtractedSource
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
 
 _ALLOWED_BINOPS: tuple[type[ast.operator], ...] = (
     ast.Add,
@@ -34,7 +39,6 @@ _ALLOWED_UNARYOPS: tuple[type[ast.unaryop], ...] = (
     ast.USub,
     ast.Not,
 )
-_ALLOWED_BOOLOPS: tuple[type[ast.boolop], ...] = (ast.And, ast.Or)
 _ALLOWED_COMPAREOPS: tuple[type[ast.cmpop], ...] = (
     ast.Eq,
     ast.NotEq,
@@ -72,6 +76,8 @@ _UNSUPPORTED_MESSAGES: dict[type[ast.AST], str] = {
     ast.DictComp: "comprehensions are not supported",
     ast.SetComp: "comprehensions are not supported",
     ast.GeneratorExp: "generator expressions are not supported",
+    ast.Break: "break statements are not supported",
+    ast.Continue: "continue statements are not supported",
     ast.Delete: "del statements are not supported",
     ast.AnnAssign: "annotated assignments are not supported",
     ast.AugAssign: "augmented assignment (e.g. +=) is not supported",
@@ -87,27 +93,6 @@ _UNSUPPORTED_MESSAGES: dict[type[ast.AST], str] = {
 # module still imports cleanly on 3.10.
 if (_try_star := getattr(ast, "TryStar", None)) is not None:
     _UNSUPPORTED_MESSAGES[_try_star] = "try/except* is not supported"
-
-
-def _is_range_call(node: ast.expr) -> bool:
-    """
-    title: Return whether a node is a call to the builtin range().
-    summary: >-
-      Only the exact shape range(...) with no keyword arguments is accepted;
-      range is looked up by name only, so a shadowed or attribute-qualified
-      "range" is rejected like any other call.
-    parameters:
-      node:
-        type: ast.expr
-    returns:
-      type: bool
-    """
-    return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "range"
-        and not node.keywords
-    )
 
 
 def _char_column(line: str, byte_offset: int) -> int:
@@ -142,12 +127,10 @@ def _diagnostic(
     summary: >-
       Reads the node's lineno/col_offset when present and converts the column
       to the one-based character contract via _char_column; falls back to no
-      location when the node carries none (rare for real parsed nodes, but kept
-      safe for synthetic ones). node.lineno is a real file line number
-      (extract_source already shifted it), while extracted.source is indexed
-      from its own first line, so the node's line is looked up at
-      extracted.source.splitlines()[lineno - extracted.lineno] rather than
-      lineno - 1.
+      location when the node carries none. node.lineno is a real file line
+      number (extract_source already shifted it), while extracted.source is
+      indexed from its own first line, so the node's line is looked up at
+      splitlines()[lineno - extracted.lineno] rather than lineno - 1.
     parameters:
       extracted:
         type: ExtractedSource
@@ -175,30 +158,74 @@ def _diagnostic(
     )
 
 
-class _SubsetValidator(ast.NodeVisitor):
+def _bound_names(node: FunctionNode) -> set[str]:
     """
-    title: Collect one diagnostic per Python construct outside the v1 subset.
+    title: Collect every name bound as a local of the function.
     summary: >-
-      A rejected node's children are not descended into, so a single bad
-      expression tree reports one diagnostic rather than one per nested node;
-      independent sibling statements (including inside if/while/for bodies) are
-      still each visited and validated in full.
+      A name is bound if it is a parameter or is assigned anywhere in the body
+      (an ordinary assignment target or a for-loop target). Any name that is
+      read but not bound is therefore a free variable (a closure capture) or a
+      module global, both of which are outside the pure v1 subset. Assignments
+      in never-executed branches still bind, matching Python's own rule that
+      any assigned name is a local.
+    parameters:
+      node:
+        type: FunctionNode
+    returns:
+      type: set[str]
+    """
+    names: set[str] = set()
+    args = node.args
+    for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
+        names.add(arg.arg)
+    if args.vararg is not None:
+        names.add(args.vararg.arg)
+    if args.kwarg is not None:
+        names.add(args.kwarg.arg)
+    for descendant in ast.walk(node):
+        if isinstance(descendant, ast.Assign):
+            for target in descendant.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+        elif isinstance(descendant, (ast.For, ast.AsyncFor)) and isinstance(
+            descendant.target, ast.Name
+        ):
+            names.add(descendant.target.id)
+    return names
+
+
+class _SubsetValidator:
+    """
+    title: Collect one diagnostic per construct outside the v1 subset.
+    summary: >-
+      Dispatches by node type via plum: each accepted construct has its own
+      visit overload, and the ast.AST overload is the fail-closed default that
+      rejects everything else, so a known-unsupported construct (with a
+      specific message) or a future Python node this pass was not updated for
+      both fail safe. A rejected node's children are not descended into, so one
+      bad subtree yields one diagnostic; independent sibling statements are
+      each validated in full.
     attributes:
       extracted:
         description: The extracted source being validated.
+      bound:
+        description: Names bound as locals or arguments of the function.
       diagnostics:
         type: list[Diagnostic]
         description: One entry per rejected construct.
     """
 
-    def __init__(self, extracted: ExtractedSource) -> None:
+    def __init__(self, extracted: ExtractedSource, bound: set[str]) -> None:
         """
         title: Initialize the validator for one function's source.
         parameters:
           extracted:
             type: ExtractedSource
+          bound:
+            type: set[str]
         """
         self.extracted = extracted
+        self.bound = bound
         self.diagnostics: list[Diagnostic] = []
 
     def _reject(self, node: ast.AST, message: str) -> None:
@@ -212,9 +239,36 @@ class _SubsetValidator(ast.NodeVisitor):
         """
         self.diagnostics.append(_diagnostic(self.extracted, node, message))
 
-    # -- statements --------------------------------------------------
+    def visit_all(self, statements: list[ast.stmt]) -> None:
+        """
+        title: Visit each statement in a block in order.
+        parameters:
+          statements:
+            type: list[ast.stmt]
+        """
+        for statement in statements:
+            self.visit(statement)
 
-    def visit_Return(self, node: ast.Return) -> None:
+    @dispatch
+    def visit(self, node: ast.AST) -> None:
+        """
+        title: Reject any node with no accepting overload (fail closed).
+        summary: >-
+          Reaching this default means the node is a known-unsupported construct
+          (looked up for a specific message) or one this validator does not
+          recognize at all; both are rejected so new or unhandled syntax fails
+          closed instead of silently passing.
+        parameters:
+          node:
+            type: ast.AST
+        """
+        message = _UNSUPPORTED_MESSAGES.get(
+            type(node), f"{type(node).__name__} is not supported"
+        )
+        self._reject(node, message)
+
+    @dispatch
+    def visit(self, node: ast.Return) -> None:
         """
         title: Validate a return statement's value, if any.
         parameters:
@@ -224,7 +278,8 @@ class _SubsetValidator(ast.NodeVisitor):
         if node.value is not None:
             self.visit(node.value)
 
-    def visit_Assign(self, node: ast.Assign) -> None:
+    @dispatch
+    def visit(self, node: ast.Assign) -> None:
         """
         title: Validate a single-target local variable assignment.
         parameters:
@@ -238,7 +293,8 @@ class _SubsetValidator(ast.NodeVisitor):
             )
         self.visit(node.value)
 
-    def visit_If(self, node: ast.If) -> None:
+    @dispatch
+    def visit(self, node: ast.If) -> None:
         """
         title: Validate an if/else statement and both branches.
         parameters:
@@ -246,23 +302,36 @@ class _SubsetValidator(ast.NodeVisitor):
             type: ast.If
         """
         self.visit(node.test)
-        for stmt in (*node.body, *node.orelse):
-            self.visit(stmt)
+        self.visit_all(node.body)
+        self.visit_all(node.orelse)
 
-    def visit_While(self, node: ast.While) -> None:
+    @dispatch
+    def visit(self, node: ast.While) -> None:
         """
         title: Validate a while loop and its body.
+        summary: >-
+          The loop's else clause is rejected: it only runs when the loop exits
+          without break, and break is itself outside the subset, so a while-
+          else is dead and needlessly complicates lowering.
         parameters:
           node:
             type: ast.While
         """
         self.visit(node.test)
-        for stmt in (*node.body, *node.orelse):
-            self.visit(stmt)
+        if node.orelse:
+            self._reject(
+                node.orelse[0], "while-else clauses are not supported"
+            )
+        self.visit_all(node.body)
 
-    def visit_For(self, node: ast.For) -> None:
+    @dispatch
+    def visit(self, node: ast.For) -> None:
         """
         title: Validate a for loop, restricted to iterating over range().
+        summary: >-
+          The iterable must be a call to the builtin range with one to three
+          positional arguments and no keywords; a range shadowed by a local or
+          argument is rejected, as is a loop else clause.
         parameters:
           node:
             type: ast.For
@@ -272,28 +341,56 @@ class _SubsetValidator(ast.NodeVisitor):
                 node.target,
                 "for-loop targets must be a single local variable",
             )
-        if _is_range_call(node.iter):
-            for arg in cast(ast.Call, node.iter).args:
-                self.visit(arg)
-        else:
+        self._visit_for_iter(node.iter)
+        if node.orelse:
+            self._reject(node.orelse[0], "for-else clauses are not supported")
+        self.visit_all(node.body)
+
+    def _visit_for_iter(self, iterable: ast.expr) -> None:
+        """
+        title: Validate a for loop's iterable as a builtin range() call.
+        parameters:
+          iterable:
+            type: ast.expr
+        """
+        if not (
+            isinstance(iterable, ast.Call)
+            and isinstance(iterable.func, ast.Name)
+            and iterable.func.id == "range"
+        ):
             self._reject(
-                node.iter,
+                iterable,
                 "for loops are only supported over range(...)",
             )
-        for stmt in (*node.body, *node.orelse):
-            self.visit(stmt)
+            return
+        if "range" in self.bound:
+            self._reject(
+                iterable,
+                "range is shadowed by a local variable or argument",
+            )
+            return
+        if iterable.keywords:
+            self._reject(iterable, "range() does not accept keyword arguments")
+            return
+        if not 1 <= len(iterable.args) <= 3:
+            self._reject(
+                iterable,
+                "range() takes one to three positional arguments",
+            )
+            return
+        for argument in iterable.args:
+            self.visit(argument)
 
-    def visit_Expr(self, node: ast.Expr) -> None:
+    @dispatch
+    def visit(self, node: ast.Expr) -> None:
         """
         title: Accept a standalone string literal, reject anything else.
         summary: >-
-          A bare string statement (a docstring, or a no-op string anywhere in
-          the body) has no compilable effect and is silently allowed. A bare
-          "yield x" is the common generator-function form and is delegated to
-          the generic unsupported-construct lookup so it gets the specific
-          generators message instead of a generic one; any other standalone
-          expression statement computes a value that is immediately discarded
-          and is rejected directly.
+          A bare string statement (a docstring, or a no-op string) has no
+          compilable effect and is allowed. A bare yield is delegated to the
+          default so it gets the specific generators message; any other
+          standalone expression computes a value that is discarded and is
+          rejected directly.
         parameters:
           node:
             type: ast.Expr
@@ -309,7 +406,8 @@ class _SubsetValidator(ast.NodeVisitor):
             node, "standalone expression statements are not supported"
         )
 
-    def visit_Pass(self, node: ast.Pass) -> None:
+    @dispatch
+    def visit(self, node: ast.Pass) -> None:
         """
         title: Accept a pass statement; it has no effect.
         parameters:
@@ -317,17 +415,28 @@ class _SubsetValidator(ast.NodeVisitor):
             type: ast.Pass
         """
 
-    # -- expressions -------------------------------------------------
-
-    def visit_Name(self, node: ast.Name) -> None:
+    @dispatch
+    def visit(self, node: ast.Name) -> None:
         """
-        title: Accept a variable reference.
+        title: Accept a bound variable reference, reject a free one.
+        summary: >-
+          Only names read in an expression reach this overload (assignment and
+          loop targets are checked without being visited). A name that is not
+          bound as a local or argument is a closure capture or a module global,
+          both outside the pure subset.
         parameters:
           node:
             type: ast.Name
         """
+        if isinstance(node.ctx, ast.Load) and node.id not in self.bound:
+            self._reject(
+                node,
+                f"reference to {node.id!r}, which is not a local variable"
+                " or argument (closures and globals are not supported)",
+            )
 
-    def visit_Constant(self, node: ast.Constant) -> None:
+    @dispatch
+    def visit(self, node: ast.Constant) -> None:
         """
         title: Accept only int, float, and bool literals.
         parameters:
@@ -339,7 +448,8 @@ class _SubsetValidator(ast.NodeVisitor):
         kind = type(node.value).__name__
         self._reject(node, f"{kind} literals are not supported")
 
-    def visit_BinOp(self, node: ast.BinOp) -> None:
+    @dispatch
+    def visit(self, node: ast.BinOp) -> None:
         """
         title: Validate an arithmetic binary expression.
         parameters:
@@ -347,12 +457,15 @@ class _SubsetValidator(ast.NodeVisitor):
             type: ast.BinOp
         """
         if not isinstance(node.op, _ALLOWED_BINOPS):
-            kind = type(node.op).__name__
-            self._reject(node, f"the {kind} operator is not supported")
+            self._reject(
+                node,
+                f"the {type(node.op).__name__} operator is not supported",
+            )
         self.visit(node.left)
         self.visit(node.right)
 
-    def visit_UnaryOp(self, node: ast.UnaryOp) -> None:
+    @dispatch
+    def visit(self, node: ast.UnaryOp) -> None:
         """
         title: Validate a unary expression.
         parameters:
@@ -360,48 +473,53 @@ class _SubsetValidator(ast.NodeVisitor):
             type: ast.UnaryOp
         """
         if not isinstance(node.op, _ALLOWED_UNARYOPS):
-            kind = type(node.op).__name__
-            self._reject(node, f"the {kind} operator is not supported")
+            self._reject(
+                node,
+                f"the {type(node.op).__name__} operator is not supported",
+            )
         self.visit(node.operand)
 
-    def visit_BoolOp(self, node: ast.BoolOp) -> None:
+    @dispatch
+    def visit(self, node: ast.BoolOp) -> None:
         """
-        title: Validate a boolean and/or expression.
+        title: Validate a boolean and/or expression's operands.
+        summary: >-
+          Python has only ``and`` and ``or`` as boolean operators, both
+          supported, so only the operands need validation.
         parameters:
           node:
             type: ast.BoolOp
         """
-        if not isinstance(node.op, _ALLOWED_BOOLOPS):  # pragma: no cover
-            # And and Or are the only boolean operators, so this guard is
-            # unreachable today; it is kept for parity with the other
-            # operator visitors and to fail closed if Python adds one.
-            kind = type(node.op).__name__
-            self._reject(node, f"the {kind} operator is not supported")
         for value in node.values:
             self.visit(value)
 
-    def visit_Compare(self, node: ast.Compare) -> None:
+    @dispatch
+    def visit(self, node: ast.Compare) -> None:
         """
         title: Validate a (possibly chained) comparison expression.
         parameters:
           node:
             type: ast.Compare
         """
-        for op in node.ops:
-            if not isinstance(op, _ALLOWED_COMPAREOPS):
-                kind = type(op).__name__
-                self._reject(node, f"the {kind} comparison is not supported")
+        for operator in node.ops:
+            if not isinstance(operator, _ALLOWED_COMPAREOPS):
+                self._reject(
+                    node,
+                    f"the {type(operator).__name__} comparison is not"
+                    " supported",
+                )
         self.visit(node.left)
         for comparator in node.comparators:
             self.visit(comparator)
 
-    def visit_Call(self, node: ast.Call) -> None:
+    @dispatch
+    def visit(self, node: ast.Call) -> None:
         """
         title: Reject a function call.
         summary: >-
-          Only reachable for calls that are not a for-loop's range(...)
-          iterator, which visit_For special-cases before it ever reaches the
-          generic expression visitor.
+          Only reachable for calls that are not a for loop's range(...)
+          iterator, which _visit_for_iter special-cases before it ever reaches
+          the generic expression walk.
         parameters:
           node:
             type: ast.Call
@@ -410,25 +528,6 @@ class _SubsetValidator(ast.NodeVisitor):
             node,
             "calling functions is not supported (only range() in a for loop)",
         )
-
-    def generic_visit(self, node: ast.AST) -> None:
-        """
-        title: Reject any node with no explicit visit_* handler.
-        summary: >-
-          Every accepted statement and expression kind has its own visit_*
-          method above; reaching this method means the node is either a known-
-          unsupported construct (looked up for a specific message) or one this
-          validator does not recognize at all, which is rejected the same way
-          so new Python syntax fails closed instead of silently passing
-          through.
-        parameters:
-          node:
-            type: ast.AST
-        """
-        message = _UNSUPPORTED_MESSAGES.get(type(node))
-        if message is None:
-            message = f"{type(node).__name__} is not supported"
-        self._reject(node, message)
 
 
 def _validate_arguments(
@@ -493,19 +592,21 @@ def validate(extracted: ExtractedSource) -> None:
     """
     title: Validate that a function uses only the supported Python subset.
     summary: >-
-      Checks the function's argument shape and walks its body, collecting one
-      diagnostic per rejected construct. A function using several unsupported
-      constructs is reported in a single UnsupportedSyntaxError carrying all of
-      them, so a user fixes everything in one pass instead of one error at a
-      time.
+      Rejects async definitions and generic (PEP 695) type parameters, checks
+      the argument shape, then walks the body collecting one diagnostic per
+      rejected construct, including free-variable reads (closures and globals).
+      A function with several unsupported constructs is reported in a single
+      UnsupportedSyntaxError carrying all of them, so a user fixes everything
+      in one pass.
     parameters:
       extracted:
         type: ExtractedSource
         description: The result of arxjit.source.extract_source.
     raises:
       UnsupportedSyntaxError: >-
-        If the function is async, has an unsupported argument shape, or its
-        body uses any construct outside the v1 subset.
+        If the function is async or generic, has an unsupported argument shape,
+        reads a free variable, or its body uses any construct outside the v1
+        subset.
     """
     node = extracted.node
     diagnostics: list[Diagnostic] = []
@@ -518,12 +619,19 @@ def validate(extracted: ExtractedSource) -> None:
                 "async function definitions are not supported",
             )
         )
+    if getattr(node, "type_params", ()):
+        diagnostics.append(
+            _diagnostic(
+                extracted,
+                node,
+                "generic functions (type parameters) are not supported",
+            )
+        )
 
     diagnostics.extend(_validate_arguments(extracted, node.args))
 
-    visitor = _SubsetValidator(extracted)
-    for stmt in node.body:
-        visitor.visit(stmt)
+    visitor = _SubsetValidator(extracted, _bound_names(node))
+    visitor.visit_all(node.body)
     diagnostics.extend(visitor.diagnostics)
 
     if diagnostics:

--- a/packages/arxjit/src/arxjit/validation.py
+++ b/packages/arxjit/src/arxjit/validation.py
@@ -16,6 +16,7 @@ summary: >-
 from __future__ import annotations
 
 import ast
+import builtins
 
 from plum import dispatch
 
@@ -24,6 +25,15 @@ from arxjit.errors import UnsupportedSyntaxError
 from arxjit.source import ExtractedSource
 
 FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+# Nodes that open a new scope: their bodies hold their own locals, so the
+# binding collector records their name but does not descend into them.
+_SCOPE_NODES: tuple[type[ast.AST], ...] = (
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+    ast.Lambda,
+    ast.ClassDef,
+)
 
 _ALLOWED_BINOPS: tuple[type[ast.operator], ...] = (
     ast.Add,
@@ -158,39 +168,117 @@ def _diagnostic(
     )
 
 
+def _target_names(target: ast.expr) -> set[str]:
+    """
+    title: Collect the names bound by an assignment or loop target.
+    summary: >-
+      Handles the tuple, list, and starred forms as well as a plain name, so a
+      target the subset rejects still registers its bindings and does not also
+      produce a spurious free-variable diagnostic for the same name.
+    parameters:
+      target:
+        type: ast.expr
+    returns:
+      type: set[str]
+    """
+    if isinstance(target, ast.Name):
+        return {target.id}
+    if isinstance(target, (ast.Tuple, ast.List)):
+        names: set[str] = set()
+        for element in target.elts:
+            names |= _target_names(element)
+        return names
+    if isinstance(target, ast.Starred):
+        return _target_names(target.value)
+    return set()
+
+
+def _parameter_names(args: ast.arguments) -> set[str]:
+    """
+    title: Collect the names bound by a function's parameter list.
+    summary: >-
+      Includes the parameter kinds the subset rejects (variadic and keyword-
+      only), so a rejected signature does not also report its own parameters as
+      free variables.
+    parameters:
+      args:
+        type: ast.arguments
+    returns:
+      type: set[str]
+    """
+    names = {
+        arg.arg for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs)
+    }
+    for variadic in (args.vararg, args.kwarg):
+        if variadic is not None:
+            names.add(variadic.arg)
+    return names
+
+
+def _statement_bindings(node: ast.AST) -> set[str]:
+    """
+    title: Collect the names a single statement or expression binds.
+    summary: >-
+      Covers ordinary and loop assignment as well as the annotated, augmented,
+      and walrus forms the subset rejects, so a rejected statement does not
+      also produce a free-variable diagnostic for the name it binds.
+    parameters:
+      node:
+        type: ast.AST
+    returns:
+      type: set[str]
+    """
+    if isinstance(node, ast.Assign):
+        names: set[str] = set()
+        for target in node.targets:
+            names |= _target_names(target)
+        return names
+    if isinstance(
+        node,
+        (
+            ast.For,
+            ast.AsyncFor,
+            ast.AnnAssign,
+            ast.AugAssign,
+            ast.NamedExpr,
+        ),
+    ):
+        return _target_names(node.target)
+    return set()
+
+
 def _bound_names(node: FunctionNode) -> set[str]:
     """
-    title: Collect every name bound as a local of the function.
-    summary: >-
-      A name is bound if it is a parameter or is assigned anywhere in the body
-      (an ordinary assignment target or a for-loop target). Any name that is
-      read but not bound is therefore a free variable (a closure capture) or a
-      module global, both of which are outside the pure v1 subset. Assignments
-      in never-executed branches still bind, matching Python's own rule that
-      any assigned name is a local.
+    title: Collect every name bound as a local of the function's own scope.
+    summary: |-
+      A name is bound if it is a parameter or is assigned in the body. Any name
+      read but not bound is a free variable (a closure capture) or a module
+      global, both outside the pure v1 subset. Assignments in never-executed
+      branches still bind, matching Python's rule that any assigned name is a
+      local.
+      Nested scopes are deliberately not descended into: a nested function,
+      lambda, or class has its own locals, so collecting them here would both
+      mask free-variable reads in this scope and misreport a nested binding as
+      shadowing an outer name. The nested definition's own name does bind in
+      this scope, so it is collected while its body is skipped.
     parameters:
       node:
         type: FunctionNode
     returns:
       type: set[str]
     """
-    names: set[str] = set()
-    args = node.args
-    for arg in (*args.posonlyargs, *args.args, *args.kwonlyargs):
-        names.add(arg.arg)
-    if args.vararg is not None:
-        names.add(args.vararg.arg)
-    if args.kwarg is not None:
-        names.add(args.kwarg.arg)
-    for descendant in ast.walk(node):
-        if isinstance(descendant, ast.Assign):
-            for target in descendant.targets:
-                if isinstance(target, ast.Name):
-                    names.add(target.id)
-        elif isinstance(descendant, (ast.For, ast.AsyncFor)) and isinstance(
-            descendant.target, ast.Name
-        ):
-            names.add(descendant.target.id)
+    names = _parameter_names(node.args)
+    pending: list[ast.AST] = list(node.body)
+    while pending:
+        current = pending.pop()
+        if isinstance(current, _SCOPE_NODES):
+            # A nested scope: its name binds here, its body does not.
+            nested_name = getattr(current, "name", None)
+            if isinstance(nested_name, str):
+                names.add(nested_name)
+            continue
+        names |= _statement_bindings(current)
+        pending.extend(ast.iter_child_nodes(current))
     return names
 
 
@@ -238,6 +326,23 @@ class _SubsetValidator:
             type: str
         """
         self.diagnostics.append(_diagnostic(self.extracted, node, message))
+
+    def _range_is_builtin(self) -> bool:
+        """
+        title: Return whether range resolves to the builtin at module level.
+        summary: >-
+          Checks the defining module's namespace, which extraction carries
+          alongside the source. When that namespace is unavailable (only for a
+          hand-built ExtractedSource; extract_source always provides it for a
+          real function) module-level shadowing cannot be observed and the name
+          is taken to be the builtin.
+        returns:
+          type: bool
+        """
+        namespace = self.extracted.globalns
+        if namespace is None:
+            return True
+        return namespace.get("range", builtins.range) is builtins.range
 
     def visit_all(self, statements: list[ast.stmt]) -> None:
         """
@@ -349,6 +454,12 @@ class _SubsetValidator:
     def _visit_for_iter(self, iterable: ast.expr) -> None:
         """
         title: Validate a for loop's iterable as a builtin range() call.
+        summary: >-
+          The callee must resolve to the builtin range, so it is rejected when
+          shadowed by a local or argument and when shadowed by a module-level
+          name in the defining module's namespace, which the AST alone cannot
+          reveal. Compiling a shadowed range as the range intrinsic would
+          silently disagree with the Python fallback.
         parameters:
           iterable:
             type: ast.expr
@@ -367,6 +478,13 @@ class _SubsetValidator:
             self._reject(
                 iterable,
                 "range is shadowed by a local variable or argument",
+            )
+            return
+        if not self._range_is_builtin():
+            self._reject(
+                iterable,
+                "range is shadowed by a module-level name, so it is not"
+                " the builtin range",
             )
             return
         if iterable.keywords:

--- a/packages/arxjit/src/arxjit/validation.py
+++ b/packages/arxjit/src/arxjit/validation.py
@@ -327,22 +327,33 @@ class _SubsetValidator:
         """
         self.diagnostics.append(_diagnostic(self.extracted, node, message))
 
-    def _range_is_builtin(self) -> bool:
+    def _range_shadow(self) -> str | None:
         """
-        title: Return whether range resolves to the builtin at module level.
+        title: Return what shadows range, or None when it is the builtin.
         summary: >-
-          Checks the defining module's namespace, which extraction carries
-          alongside the source. When that namespace is unavailable (only for a
-          hand-built ExtractedSource; extract_source always provides it for a
-          real function) module-level shadowing cannot be observed and the name
-          is taken to be the builtin.
+          A for loop's range must resolve to builtins.range, and it can be
+          shadowed in three places: this function's own locals and arguments,
+          an enclosing function's scope (a closure capture), and the defining
+          module's namespace. Only the first is visible in the AST, so the
+          other two are read from the context extraction carries alongside the
+          source. When that namespace is unavailable (only for a hand-built
+          ExtractedSource; extract_source always provides it for a real
+          function) module-level shadowing cannot be observed and the name is
+          taken to be the builtin.
         returns:
-          type: bool
+          type: str | None
         """
+        if "range" in self.bound:
+            return "a local variable or argument"
+        if "range" in self.extracted.freevars:
+            return "an enclosing function's variable"
         namespace = self.extracted.globalns
-        if namespace is None:
-            return True
-        return namespace.get("range", builtins.range) is builtins.range
+        if (
+            namespace is not None
+            and namespace.get("range", builtins.range) is not builtins.range
+        ):
+            return "a module-level name"
+        return None
 
     def visit_all(self, statements: list[ast.stmt]) -> None:
         """
@@ -455,11 +466,11 @@ class _SubsetValidator:
         """
         title: Validate a for loop's iterable as a builtin range() call.
         summary: >-
-          The callee must resolve to the builtin range, so it is rejected when
-          shadowed by a local or argument and when shadowed by a module-level
-          name in the defining module's namespace, which the AST alone cannot
-          reveal. Compiling a shadowed range as the range intrinsic would
-          silently disagree with the Python fallback.
+          The callee must resolve to builtins.range, so it is rejected whenever
+          the name is shadowed, whether by a local or argument, an enclosing
+          function's variable, or a module-level name. Compiling a shadowed
+          range as the range intrinsic would silently disagree with the Python
+          fallback, which raises TypeError.
         parameters:
           iterable:
             type: ast.expr
@@ -474,17 +485,12 @@ class _SubsetValidator:
                 "for loops are only supported over range(...)",
             )
             return
-        if "range" in self.bound:
+        shadow = self._range_shadow()
+        if shadow is not None:
             self._reject(
                 iterable,
-                "range is shadowed by a local variable or argument",
-            )
-            return
-        if not self._range_is_builtin():
-            self._reject(
-                iterable,
-                "range is shadowed by a module-level name, so it is not"
-                " the builtin range",
+                f"range is shadowed by {shadow}, so it is not the"
+                " builtin range",
             )
             return
         if iterable.keywords:

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -9,7 +9,6 @@ import importlib.util
 import inspect
 import linecache
 import pathlib
-import sys
 import tokenize
 
 from typing import Any, Callable
@@ -516,11 +515,12 @@ def test_malformed_fstring_column_is_validated(
     """
     title: A malformed f-string never yields a misleading column.
     summary: >-
-      On Python 3.10 and 3.11 the parser reports f-string errors against a
-      synthetic string built from the replacement expression, so the offset
-      does not point into the real source line and the diagnostic column must
-      fall back to None; newer versions report real file locations and keep a
-      column.
+      For a malformed f-string, some Python versions report the error offset
+      against a synthetic string built from the replacement expression rather
+      than the real source line, and the exact behavior varies by CPython patch
+      level. The invariant _column_of guarantees is version-independent: the
+      diagnostic column is either absent or a real position within the source
+      line, never a bogus synthetic offset.
     parameters:
       monkeypatch:
         type: pytest.MonkeyPatch
@@ -543,16 +543,10 @@ def test_malformed_fstring_column_is_validated(
     assert isinstance(caught.value.__cause__, SyntaxError)
     (diagnostic,) = caught.value.diagnostics
     assert diagnostic.line == 5
-    if sys.version_info < (3, 12):
-        assert diagnostic.column is None
-    elif sys.version_info >= (3, 13):
-        assert diagnostic.column is not None
-    else:
-        # 3.12 straddles the PEP 701 transition; either a validated
-        # column or the None fallback is acceptable, never a bogus one.
-        assert diagnostic.column is None or diagnostic.column <= len(
-            'x = f"prefix {a b}"'
-        )
+    line_length = len('x = f"prefix {a b}"')
+    assert (
+        diagnostic.column is None or 1 <= diagnostic.column <= line_length + 1
+    )
 
 
 def test_corrupted_source_file_is_rejected(

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -758,6 +758,63 @@ def test_column_validation_of_syntax_errors() -> None:
     assert _column_of(syntax_error(1, 2, "(a b)\n"), text) is None
 
 
+def test_defining_module_namespace_is_preserved() -> None:
+    """
+    title: Extraction carries the function's defining module namespace.
+    summary: >-
+      Later stages need it to detect module-level shadowing of a name the
+      compiler treats as a builtin, which the AST alone cannot reveal. The
+      namespace is the real module globals, so a name defined in this test
+      module is visible through it.
+    """
+    extracted = extract_source(sample_add)
+    assert extracted.globalns is not None
+    assert extracted.globalns["sample_add"] is sample_add
+
+
+def test_namespace_is_taken_from_the_wrapped_function() -> None:
+    """
+    title: A wrapper's namespace resolves to the wrapped function's module.
+    summary: >-
+      getsourcelines follows __wrapped__, so the namespace must come from the
+      same function as the retrieved source; here the wrapper is compiled in a
+      bare namespace while the wrapped function belongs to this module.
+    """
+    namespace: dict[str, Any] = {
+        "functools": functools,
+        "sample_add": sample_add,
+    }
+    exec(
+        compile(
+            "@functools.wraps(sample_add)\n"
+            "def wrapper(*args, **kwargs):\n"
+            "    return sample_add(*args, **kwargs)\n",
+            "<wrapper>",
+            "exec",
+        ),
+        namespace,
+    )
+    extracted = extract_source(namespace["wrapper"])
+    assert extracted.globalns is not None
+    assert extracted.globalns["sample_add"] is sample_add
+    # A name of this module that the wrapper's own namespace never held,
+    # proving the namespace is the wrapped function's, not the exec one.
+    assert "sample_decorated" not in namespace
+    assert extracted.globalns["sample_decorated"] is sample_decorated
+
+
+def test_namespace_is_excluded_from_repr_and_equality() -> None:
+    """
+    title: The carried namespace does not affect repr or equality.
+    summary: >-
+      It is incidental runtime context rather than part of the extracted
+      source, and a module namespace would otherwise dominate the repr.
+    """
+    extracted = extract_source(sample_add)
+    assert "globalns" not in repr(extracted)
+    assert extracted == dataclasses.replace(extracted, globalns={"x": 1})
+
+
 def test_extracted_source_is_frozen() -> None:
     """
     title: ExtractedSource instances are immutable.

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -803,6 +803,39 @@ def test_namespace_is_taken_from_the_wrapped_function() -> None:
     assert extracted.globalns["sample_decorated"] is sample_decorated
 
 
+def test_captured_names_are_preserved() -> None:
+    """
+    title: Extraction records the names captured from enclosing scopes.
+    summary: >-
+      Later stages need them to tell a closure capture apart from a builtin of
+      the same name; a function that captures nothing records an empty set.
+    """
+
+    def outer() -> PyFunc:
+        """
+        title: Return a nested function capturing one enclosing local.
+        returns:
+          type: PyFunc
+        """
+        captured = 5
+
+        def inner(x: int) -> int:
+            """
+            title: Multiply the argument by the captured value.
+            parameters:
+              x:
+                type: int
+            returns:
+              type: int
+            """
+            return x * captured
+
+        return inner
+
+    assert extract_source(outer()).freevars == frozenset({"captured"})
+    assert extract_source(sample_add).freevars == frozenset()
+
+
 def test_namespace_is_excluded_from_repr_and_equality() -> None:
     """
     title: The carried namespace does not affect repr or equality.

--- a/packages/arxjit/tests/test_validation.py
+++ b/packages/arxjit/tests/test_validation.py
@@ -13,7 +13,6 @@ from arxjit.errors import UnsupportedSyntaxError
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.validation import (
     _char_column,
-    _is_range_call,
     _SubsetValidator,
     validate,
 )
@@ -408,8 +407,60 @@ def test_for_tuple_target_is_rejected() -> None:
             total = total + i
         return total
 
+    diagnostics = _rejected(sample)
+    assert any("for-loop targets" in d.message for d in diagnostics)
+
+
+def test_for_else_clause_is_rejected() -> None:
+    """
+    title: A for-else clause is rejected.
+    summary: >-
+      The loop else pairs with break, which is outside the subset, so it is
+      rejected rather than silently accepted and left for lowering.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Attach an else clause to a for loop.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        total = 0
+        for i in range(x):
+            total = total + i
+        else:  # noqa: PLW0120
+            total = 0
+        return total
+
     (diagnostic,) = _rejected(sample)
-    assert "for-loop targets" in diagnostic.message
+    assert "for-else clauses are not supported" in diagnostic.message
+
+
+def test_while_else_clause_is_rejected() -> None:
+    """
+    title: A while-else clause is rejected.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Attach an else clause to a while loop.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        while x > 0:
+            x = x - 1
+        else:  # noqa: PLW0120
+            x = 0
+        return x
+
+    (diagnostic,) = _rejected(sample)
+    assert "while-else clauses are not supported" in diagnostic.message
 
 
 def test_varargs_are_rejected() -> None:
@@ -582,15 +633,141 @@ def test_char_column_converts_multibyte_prefixes() -> None:
     assert _char_column(line, real_byte_offset) == char_index + 1
 
 
-def test_is_range_call_rejects_non_range_shapes() -> None:
+def test_free_variable_read_is_rejected() -> None:
     """
-    title: _is_range_call only accepts a bare name call to range().
+    title: Reading a name that is neither an argument nor a local is rejected.
+    summary: >-
+      The extracted node of a nested function keeps its free variables as plain
+      ast.Name loads; without binding analysis a closure capture would pass
+      validation, so this pins that a free read is rejected.
     """
-    assert _is_range_call(ast.parse("range(5)", mode="eval").body)
-    assert not _is_range_call(ast.parse("range(stop=5)", mode="eval").body)
-    assert not _is_range_call(ast.parse("mod.range(5)", mode="eval").body)
-    assert not _is_range_call(ast.parse("[1, 2]", mode="eval").body)
-    assert not _is_range_call(ast.parse("x", mode="eval").body)
+
+    def sample(x: int) -> int:
+        """
+        title: Multiply by an undefined free variable.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * scale  # noqa: F821
+
+    (diagnostic,) = _rejected(sample)
+    assert "'scale'" in diagnostic.message
+    assert "closures and globals are not supported" in diagnostic.message
+
+
+def test_global_read_is_rejected() -> None:
+    """
+    title: Reading a module global is rejected like a closure capture.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Multiply by a module-level constant.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * _SAMPLE_GLOBAL
+
+    (diagnostic,) = _rejected(sample)
+    assert "'_SAMPLE_GLOBAL'" in diagnostic.message
+
+
+def test_shadowed_range_is_rejected() -> None:
+    """
+    title: A range shadowed by an argument is not treated as the builtin.
+    """
+
+    def sample(range: int) -> int:
+        """
+        title: Loop over a parameter named range.
+        parameters:
+          range:
+            type: int
+        returns:
+          type: int
+        """
+        total = 0
+        for i in range(3):
+            total = total + i
+        return total
+
+    (diagnostic,) = _rejected(sample)
+    assert "range is shadowed" in diagnostic.message
+
+
+def test_range_with_too_many_arguments_is_rejected() -> None:
+    """
+    title: A range() call with four arguments is rejected.
+    """
+
+    def sample(n: int) -> int:
+        """
+        title: Loop over range with four arguments.
+        parameters:
+          n:
+            type: int
+        returns:
+          type: int
+        """
+        total = 0
+        for i in range(1, 2, 3, 4):
+            total = total + i
+        return total
+
+    (diagnostic,) = _rejected(sample)
+    assert "one to three positional arguments" in diagnostic.message
+
+
+def test_range_with_no_arguments_is_rejected() -> None:
+    """
+    title: A range() call with no arguments is rejected.
+    """
+
+    def sample(n: int) -> int:
+        """
+        title: Loop over range with no arguments.
+        parameters:
+          n:
+            type: int
+        returns:
+          type: int
+        """
+        total = 0
+        for i in range():
+            total = total + i
+        return total
+
+    (diagnostic,) = _rejected(sample)
+    assert "one to three positional arguments" in diagnostic.message
+
+
+def test_range_with_keyword_argument_is_rejected() -> None:
+    """
+    title: A keyword-argument call to range(...) is rejected.
+    """
+
+    def sample(n: int) -> int:
+        """
+        title: Call range with a keyword argument.
+        parameters:
+          n:
+            type: int
+        returns:
+          type: int
+        """
+        total = 0
+        for i in range(stop=n):
+            total = total + i
+        return total
+
+    (diagnostic,) = _rejected(sample)
+    assert "does not accept keyword arguments" in diagnostic.message
 
 
 def test_unrecognized_node_type_falls_back_to_a_generic_message() -> None:
@@ -599,9 +776,9 @@ def test_unrecognized_node_type_falls_back_to_a_generic_message() -> None:
       A node type absent from the whitelist and the message table still gets a
       rejection, not a silent pass.
     summary: >-
-      Exercises generic_visit's fail-closed fallback directly, covering any
-      future Python syntax this validator was not updated for, without
-      depending on a specific version-gated construct being available.
+      Exercises the fail-closed ast.AST dispatch fallback directly, covering
+      any future Python syntax this validator was not updated for, without
+      depending on a version-gated construct being available.
     """
 
     class _Unknown(ast.AST):
@@ -622,7 +799,35 @@ def test_unrecognized_node_type_falls_back_to_a_generic_message() -> None:
         lineno=1,
         node=ast.parse("def f():\n    pass\n").body[0],
     )
-    validator = _SubsetValidator(extracted)
-    validator.generic_visit(_Unknown())
+    validator = _SubsetValidator(extracted, set())
+    validator.visit(_Unknown())
     (diagnostic,) = validator.diagnostics
     assert "_Unknown is not supported" in diagnostic.message
+
+
+def test_generic_function_is_rejected() -> None:
+    """
+    title: A PEP 695 generic function (type parameters) is rejected.
+    summary: >-
+      The type-parameter syntax parses only on Python 3.12+, so rather than
+      version-gate the test, type_params is set on a parsed node directly
+      (validate only checks that the list is non-empty); this exercises the
+      rejection on every supported Python version.
+    """
+    source = "def identity(x: int) -> int:\n    return x\n"
+    node = ast.parse(source).body[0]
+    node.type_params = ["T"]  # type: ignore[attr-defined,list-item]
+    extracted = ExtractedSource(
+        filename="<generic>",
+        source=source,
+        lineno=1,
+        node=node,  # type: ignore[arg-type]
+    )
+    with pytest.raises(UnsupportedSyntaxError) as caught:
+        validate(extracted)
+    assert any(
+        "generic functions" in d.message for d in caught.value.diagnostics
+    )
+
+
+_SAMPLE_GLOBAL = 2

--- a/packages/arxjit/tests/test_validation.py
+++ b/packages/arxjit/tests/test_validation.py
@@ -1,0 +1,628 @@
+"""
+title: Tests for Python-subset validation.
+"""
+
+import ast
+
+from typing import Any, Callable
+
+import pytest
+
+from arxjit.diagnostics import DiagnosticSeverity
+from arxjit.errors import UnsupportedSyntaxError
+from arxjit.source import ExtractedSource, extract_source
+from arxjit.validation import (
+    _char_column,
+    _is_range_call,
+    _SubsetValidator,
+    validate,
+)
+
+PyFunc = Callable[..., Any]
+
+
+def _rejected(fn: PyFunc) -> list[Any]:
+    """
+    title: Extract, validate, and return the diagnostics of a rejection.
+    summary: >-
+      Asserts the function is rejected and returns its diagnostics, so
+      individual tests can focus on which messages and locations matter.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: list[Any]
+    """
+    extracted = extract_source(fn)
+    with pytest.raises(UnsupportedSyntaxError) as caught:
+        validate(extracted)
+    return caught.value.diagnostics
+
+
+def sample_valid(count: int, flag: bool) -> int:
+    """
+    title: Exercise the entire v1-supported subset in one function.
+    parameters:
+      count:
+        type: int
+      flag:
+        type: bool
+    returns:
+      type: int
+    """
+    total = 0
+    if flag:
+        step = 1
+    else:
+        step = -1
+    i = 0
+    while i < count:
+        if i % 2 == 0 and i > 0:
+            total = total + i * step
+        elif i == 0:
+            pass
+        else:
+            total = total - 1
+        i = i + 1
+    for j in range(count):
+        total = total + j
+    return total
+
+
+def test_supported_subset_passes_validation() -> None:
+    """
+    title: A function using only the v1 subset validates cleanly.
+    """
+    extracted = extract_source(sample_valid)
+    validate(extracted)
+
+
+def test_chained_comparison_is_accepted() -> None:
+    """
+    title: A chained comparison (a < b < c) is a single valid Compare node.
+    """
+
+    def sample(a: int, b: int, c: int) -> bool:
+        """
+        title: Check a is strictly between b and c.
+        parameters:
+          a:
+            type: int
+          b:
+            type: int
+          c:
+            type: int
+        returns:
+          type: bool
+        """
+        return b < a < c
+
+    extracted = extract_source(sample)
+    validate(extracted)
+
+
+def test_async_function_is_rejected() -> None:
+    """
+    title: An async top-level function is rejected as a whole.
+    """
+
+    async def sample(x: int) -> int:
+        """
+        title: Return the argument, asynchronously.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x
+
+    (diagnostic,) = _rejected(sample)
+    assert "async function definitions" in diagnostic.message
+    assert diagnostic.severity is DiagnosticSeverity.ERROR
+
+
+def test_list_literal_is_rejected() -> None:
+    """
+    title: A list literal is rejected.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Build a list.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        values = [x, 1]
+        return values[0]
+
+    diagnostics = _rejected(sample)
+    assert any("list literals" in d.message for d in diagnostics)
+
+
+def test_yield_statement_gets_the_generators_message() -> None:
+    """
+    title: A bare "yield x" gets the specific generators message.
+    summary: >-
+      Regression test: visit_Expr must delegate Yield/YieldFrom to the generic
+      unsupported-construct lookup instead of reporting the generic "standalone
+      expression statements" message.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Yield the argument, making this a generator function.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        yield x
+
+    (diagnostic,) = _rejected(sample)
+    assert "generators" in diagnostic.message
+    assert "standalone expression" not in diagnostic.message
+
+
+def test_bare_call_expression_is_rejected() -> None:
+    """
+    title: A bare call statement (not assigned or returned) is rejected.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Call a builtin and discard its result.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        abs(x)
+        return x
+
+    (diagnostic,) = _rejected(sample)
+    assert "standalone expression statements" in diagnostic.message
+
+
+def test_docstring_is_not_rejected() -> None:
+    """
+    title: A function docstring does not count against the subset.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Return the argument unchanged.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x
+
+    extracted = extract_source(sample)
+    validate(extracted)
+
+
+def test_pass_is_not_rejected() -> None:
+    """
+    title: A pass statement is accepted as a no-op.
+    """
+
+    def sample(flag: bool) -> int:
+        """
+        title: Branch without doing anything in the else arm.
+        parameters:
+          flag:
+            type: bool
+        returns:
+          type: int
+        """
+        if flag:
+            pass
+        else:
+            pass
+        return 0
+
+    extracted = extract_source(sample)
+    validate(extracted)
+
+
+def test_bitwise_operator_is_rejected() -> None:
+    """
+    title: A bitwise operator is outside the v1 arithmetic subset.
+    """
+
+    def sample(x: int, y: int) -> int:
+        """
+        title: Bitwise-and two integers.
+        parameters:
+          x:
+            type: int
+          y:
+            type: int
+        returns:
+          type: int
+        """
+        return x & y
+
+    (diagnostic,) = _rejected(sample)
+    assert "BitAnd" in diagnostic.message
+
+
+def test_string_constant_is_rejected() -> None:
+    """
+    title: A non-scalar (string) literal used as a value is rejected.
+    """
+
+    def sample(flag: bool) -> str:
+        """
+        title: Return a fixed string.
+        parameters:
+          flag:
+            type: bool
+        returns:
+          type: str
+        """
+        return "hello"
+
+    (diagnostic,) = _rejected(sample)
+    assert "str literals are not supported" in diagnostic.message
+
+
+def test_multiple_violations_are_all_collected() -> None:
+    """
+    title: A function with several violations reports all of them at once.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Combine three unsupported constructs.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        import math  # noqa: F401, PLC0415
+
+        f = lambda y: y  # noqa: E731
+        values = [x, 1]
+        return f(values[0])
+
+    diagnostics = _rejected(sample)
+    messages = " | ".join(d.message for d in diagnostics)
+    assert "lambda expressions" in messages
+    assert "list literals" in messages
+    assert "import statements" in messages
+    assert len(diagnostics) >= 3
+
+
+def test_multiple_assignment_targets_are_rejected() -> None:
+    """
+    title: A chained assignment (a = b = x) is rejected.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Assign to two names at once.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        a = b = x
+        return a + b
+
+    (diagnostic,) = _rejected(sample)
+    assert "single local variable" in diagnostic.message
+
+
+def test_bitwise_not_is_rejected() -> None:
+    """
+    title: The unary bitwise-not operator is rejected.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Bitwise-invert an integer.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return ~x
+
+    (diagnostic,) = _rejected(sample)
+    assert "Invert" in diagnostic.message
+
+
+def test_identity_comparison_is_rejected() -> None:
+    """
+    title: An identity comparison (is) is outside the comparison subset.
+    """
+
+    def sample(x: int, y: int) -> bool:
+        """
+        title: Compare two values by identity.
+        parameters:
+          x:
+            type: int
+          y:
+            type: int
+        returns:
+          type: bool
+        """
+        return x is y
+
+    (diagnostic,) = _rejected(sample)
+    assert "Is comparison" in diagnostic.message
+
+
+def test_for_over_non_range_is_rejected() -> None:
+    """
+    title: A for loop over something other than range(...) is rejected.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Iterate over a bare name instead of range(...).
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        total = 0
+        for i in x:
+            total = total + i
+        return total
+
+    (diagnostic,) = _rejected(sample)
+    assert "for loops are only supported over range" in diagnostic.message
+
+
+def test_for_tuple_target_is_rejected() -> None:
+    """
+    title: A for-loop tuple-unpacking target is rejected.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Unpack a tuple target in a for loop.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        total = 0
+        for i, j in range(x):
+            total = total + i
+        return total
+
+    (diagnostic,) = _rejected(sample)
+    assert "for-loop targets" in diagnostic.message
+
+
+def test_varargs_are_rejected() -> None:
+    """
+    title: A *args parameter is rejected.
+    """
+
+    def sample(*values: int) -> int:
+        """
+        title: Accept a variable number of positional arguments.
+        parameters:
+          values:
+            type: int
+            variadic: positional
+        returns:
+          type: int
+        """
+        return 0
+
+    diagnostics = _rejected(sample)
+    assert any(
+        "variadic positional arguments" in d.message for d in diagnostics
+    )
+
+
+def test_kwargs_are_rejected() -> None:
+    """
+    title: A **kwargs parameter is rejected.
+    """
+
+    def sample(**values: int) -> int:
+        """
+        title: Accept a variable number of keyword arguments.
+        parameters:
+          values:
+            type: int
+            variadic: keyword
+        returns:
+          type: int
+        """
+        return 0
+
+    diagnostics = _rejected(sample)
+    assert any("variadic keyword arguments" in d.message for d in diagnostics)
+
+
+def test_keyword_only_arguments_are_rejected() -> None:
+    """
+    title: A keyword-only argument is rejected.
+    """
+
+    def sample(x: int, *, y: int) -> int:
+        """
+        title: Accept a keyword-only argument.
+        parameters:
+          x:
+            type: int
+          y:
+            type: int
+        returns:
+          type: int
+        """
+        return x + y
+
+    (diagnostic,) = _rejected(sample)
+    assert "keyword-only arguments" in diagnostic.message
+
+
+def test_default_argument_values_are_rejected() -> None:
+    """
+    title: A default argument value is rejected.
+    """
+
+    def sample(x: int, y: int = 1) -> int:
+        """
+        title: Accept an argument with a default value.
+        parameters:
+          x:
+            type: int
+          y:
+            type: int
+        returns:
+          type: int
+        """
+        return x + y
+
+    (diagnostic,) = _rejected(sample)
+    assert "default argument values" in diagnostic.message
+
+
+def test_column_points_at_the_real_file() -> None:
+    """
+    title: A diagnostic's line and column point at the real source file.
+    summary: >-
+      Regression test for the extracted-source line-offset fix: node.lineno is
+      a real file line number, not an index into ExtractedSource.source, so the
+      diagnostic must locate the correct real line before converting its
+      column.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Build an unsupported list literal.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return [x, 1]
+
+    (diagnostic,) = _rejected(sample)
+    with open(__file__, encoding="utf-8") as stream:
+        real_line = stream.readlines()[diagnostic.line - 1]
+    assert "[x, 1]" in real_line
+    assert diagnostic.column is not None
+    assert real_line[diagnostic.column - 1 :].startswith("[x, 1]")
+
+
+def test_nested_function_diagnostics_point_at_the_real_file() -> None:
+    """
+    title: Diagnostics from a non-module-level function are still file-true.
+    summary: >-
+      A function defined inside another starts partway through the file,
+      exercising the extracted.lineno offset the module-level cases above do
+      not.
+    """
+
+    def outer() -> PyFunc:
+        """
+        title: Define and return a nested function containing a violation.
+        returns:
+          type: PyFunc
+        """
+
+        def inner(x: int) -> int:
+            """
+            title: Build an unsupported list literal.
+            parameters:
+              x:
+                type: int
+            returns:
+              type: int
+            """
+            return [x, 1]
+
+        return inner
+
+    (diagnostic,) = _rejected(outer())
+    with open(__file__, encoding="utf-8") as stream:
+        real_line = stream.readlines()[diagnostic.line - 1]
+    assert "[x, 1]" in real_line
+    assert real_line[diagnostic.column - 1 :].startswith("[x, 1]")
+
+
+def test_char_column_converts_multibyte_prefixes() -> None:
+    """
+    title: _char_column converts a UTF-8 byte offset to a character column.
+    summary: >-
+      A non-ASCII character earlier on the line makes the byte offset diverge
+      from the character index; this directly pins the conversion independent
+      of the ast probing above.
+    """
+    line = '    x = "héllo" + [1, 2]'
+    char_index = line.index("[")
+    # ast reports col_offset as a UTF-8 byte offset; the two-byte "é"
+    # makes it exceed the character index by exactly one.
+    real_byte_offset = len(line[:char_index].encode("utf-8"))
+    assert real_byte_offset == char_index + 1
+    assert _char_column(line, real_byte_offset) == char_index + 1
+
+
+def test_is_range_call_rejects_non_range_shapes() -> None:
+    """
+    title: _is_range_call only accepts a bare name call to range().
+    """
+    assert _is_range_call(ast.parse("range(5)", mode="eval").body)
+    assert not _is_range_call(ast.parse("range(stop=5)", mode="eval").body)
+    assert not _is_range_call(ast.parse("mod.range(5)", mode="eval").body)
+    assert not _is_range_call(ast.parse("[1, 2]", mode="eval").body)
+    assert not _is_range_call(ast.parse("x", mode="eval").body)
+
+
+def test_unrecognized_node_type_falls_back_to_a_generic_message() -> None:
+    """
+    title: >-
+      A node type absent from the whitelist and the message table still gets a
+      rejection, not a silent pass.
+    summary: >-
+      Exercises generic_visit's fail-closed fallback directly, covering any
+      future Python syntax this validator was not updated for, without
+      depending on a specific version-gated construct being available.
+    """
+
+    class _Unknown(ast.AST):
+        """
+        title: A stand-in ast node type absent from every lookup table.
+        attributes:
+          _fields:
+            type: tuple[str, Ellipsis]
+        """
+
+        _fields: tuple[str, ...] = ()
+        lineno = 1
+        col_offset = 0
+
+    extracted = ExtractedSource(
+        filename="synthetic.py",
+        source="def f():\n    pass\n",
+        lineno=1,
+        node=ast.parse("def f():\n    pass\n").body[0],
+    )
+    validator = _SubsetValidator(extracted)
+    validator.generic_visit(_Unknown())
+    (diagnostic,) = validator.diagnostics
+    assert "_Unknown is not supported" in diagnostic.message

--- a/packages/arxjit/tests/test_validation.py
+++ b/packages/arxjit/tests/test_validation.py
@@ -702,6 +702,45 @@ def test_shadowed_range_is_rejected() -> None:
     assert "range is shadowed" in diagnostic.message
 
 
+def test_closure_captured_range_shadow_is_rejected() -> None:
+    """
+    title: A range captured from an enclosing scope is rejected.
+    summary: >-
+      An enclosing function's local shadows the builtin for the whole nested
+      function, which Python resolves through the closure (a TypeError when it
+      is not callable). The capture is a plain Name load in the extracted AST,
+      indistinguishable from the builtin, so the captured names carried by
+      extraction are what reveal it.
+    """
+
+    def outer() -> PyFunc:
+        """
+        title: Return a kernel that captures a local named range.
+        returns:
+          type: PyFunc
+        """
+        range = 5
+
+        def kernel(n: int) -> int:
+            """
+            title: Loop over the captured range.
+            parameters:
+              n:
+                type: int
+            returns:
+              type: int
+            """
+            total = 0
+            for i in range(n):
+                total = total + i
+            return total
+
+        return kernel
+
+    (diagnostic,) = _rejected(outer())
+    assert "enclosing function's variable" in diagnostic.message
+
+
 def test_module_level_range_shadow_is_rejected() -> None:
     """
     title: A module-global that shadows range is rejected.

--- a/packages/arxjit/tests/test_validation.py
+++ b/packages/arxjit/tests/test_validation.py
@@ -12,6 +12,7 @@ from arxjit.diagnostics import DiagnosticSeverity
 from arxjit.errors import UnsupportedSyntaxError
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.validation import (
+    _bound_names,
     _char_column,
     _SubsetValidator,
     validate,
@@ -701,6 +702,133 @@ def test_shadowed_range_is_rejected() -> None:
     assert "range is shadowed" in diagnostic.message
 
 
+def test_module_level_range_shadow_is_rejected() -> None:
+    """
+    title: A module-global that shadows range is rejected.
+    summary: >-
+      A module-level ``range = 42`` makes the call a TypeError in Python, so
+      compiling it as the range intrinsic would silently change behavior. The
+      shadowing is invisible in the AST, so the defining module's namespace
+      carried by extraction is what reveals it.
+    """
+    source = (
+        "def kernel(n: int) -> int:\n"
+        "    total = 0\n"
+        "    for i in range(n):\n"
+        "        total = total + i\n"
+        "    return total\n"
+    )
+    extracted = ExtractedSource(
+        filename="<shadowed>",
+        source=source,
+        lineno=1,
+        node=ast.parse(source).body[0],  # type: ignore[arg-type]
+        globalns={"range": 42},
+    )
+    with pytest.raises(UnsupportedSyntaxError) as caught:
+        validate(extracted)
+    (diagnostic,) = caught.value.diagnostics
+    assert "shadowed by a module-level name" in diagnostic.message
+
+
+def test_module_namespace_without_shadowing_is_accepted() -> None:
+    """
+    title: A module namespace that leaves range alone validates cleanly.
+    summary: >-
+      Covers both an unrelated global and the builtin bound explicitly under
+      its own name, neither of which shadows the intrinsic.
+    """
+    source = (
+        "def kernel(n: int) -> int:\n"
+        "    total = 0\n"
+        "    for i in range(n):\n"
+        "        total = total + i\n"
+        "    return total\n"
+    )
+    for namespace in ({"other": 1}, {"range": range}, None):
+        extracted = ExtractedSource(
+            filename="<clean>",
+            source=source,
+            lineno=1,
+            node=ast.parse(source).body[0],  # type: ignore[arg-type]
+            globalns=namespace,
+        )
+        validate(extracted)
+
+
+def test_nested_scope_binding_does_not_leak_outward() -> None:
+    """
+    title: A name assigned in a nested scope is not a binding of this one.
+    summary: >-
+      Regression test: collecting bindings with ast.walk descended into the
+      nested function and treated its ``range`` local as shadowing the builtin
+      in the outer scope, producing a misleading diagnostic. Only the nested
+      definition itself should be reported.
+    """
+
+    def sample(n: int) -> int:
+        """
+        title: Loop over range while a nested helper binds the name range.
+        parameters:
+          n:
+            type: int
+        returns:
+          type: int
+        """
+
+        def helper() -> int:
+            """
+            title: Bind and return a local named range.
+            returns:
+              type: int
+            """
+            range = 10
+            return range
+
+        total = 0
+        for i in range(n):
+            total = total + i
+        return total
+
+    diagnostics = _rejected(sample)
+    messages = [d.message for d in diagnostics]
+    assert any("nested function definitions" in m for m in messages)
+    assert not any("range is shadowed" in m for m in messages)
+
+
+def test_nested_scope_binding_does_not_hide_a_free_variable() -> None:
+    """
+    title: A nested scope's local does not mask an outer free-variable read.
+    summary: >-
+      Regression test for the collect-all-at-once guarantee: the nested
+      function's ``scale`` local made the outer read of ``scale`` look bound,
+      so only one of the two problems was reported.
+    """
+
+    def sample() -> int:
+        """
+        title: Read a name that only a nested helper binds.
+        returns:
+          type: int
+        """
+
+        def helper() -> int:
+            """
+            title: Bind and return a local named scale.
+            returns:
+              type: int
+            """
+            scale = 2
+            return scale
+
+        return scale  # noqa: F821
+
+    diagnostics = _rejected(sample)
+    messages = [d.message for d in diagnostics]
+    assert any("nested function definitions" in m for m in messages)
+    assert any("'scale'" in m for m in messages)
+
+
 def test_range_with_too_many_arguments_is_rejected() -> None:
     """
     title: A range() call with four arguments is rejected.
@@ -768,6 +896,57 @@ def test_range_with_keyword_argument_is_rejected() -> None:
 
     (diagnostic,) = _rejected(sample)
     assert "does not accept keyword arguments" in diagnostic.message
+
+
+def test_binding_collector_handles_every_target_shape() -> None:
+    """
+    title: The binding collector records each binding form of one scope.
+    summary: >-
+      Tuple, list, and starred targets each bind their names, while an
+      attribute or subscript target binds none. The annotated, augmented, and
+      walrus forms bind their target even though the subset rejects the
+      statements themselves, so a rejected statement does not also report a
+      spurious free variable. A nested scope contributes its own name but never
+      its locals.
+    """
+    source = (
+        "def kernel(a, /, b, *args, c=1, **kwargs):\n"
+        "    first, *rest = b\n"
+        "    [second, third] = b\n"
+        "    holder.attr = b\n"
+        "    holder[0] = b\n"
+        "    annotated: int = b\n"
+        "    counter = 0\n"
+        "    counter += 1\n"
+        "    while (walrus := b):\n"
+        "        pass\n"
+        "    for i in range(3):\n"
+        "        pass\n"
+        "    def nested():\n"
+        "        hidden = 1\n"
+        "        return hidden\n"
+        "    class Local:\n"
+        "        member = 1\n"
+        "    return a\n"
+    )
+    node = ast.parse(source).body[0]
+    assert _bound_names(node) == {  # type: ignore[arg-type]
+        "a",
+        "b",
+        "args",
+        "c",
+        "kwargs",
+        "first",
+        "rest",
+        "second",
+        "third",
+        "annotated",
+        "counter",
+        "walrus",
+        "i",
+        "nested",
+        "Local",
+    }
 
 
 def test_unrecognized_node_type_falls_back_to_a_generic_message() -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -200,6 +200,7 @@ develop = true
 
 [package.dependencies]
 astx = "1.23.1"
+plum-dispatch = ">=2"
 pyirx = "1.23.1"
 
 [package.source]


### PR DESCRIPTION
## Summary

Sprint 2, Python-subset validation (wiki "Proposed Issue 4: Define and validate the supported pure-Python subset"). Builds on source extraction (#96/#98): it adds `arxjit.validation`, the stage that runs after `extract_source`, walking the parsed function and accepting only the v1 supported subset while rejecting everything else with clear, located diagnostics.

Issue 4 checklist coverage:

- [x] Implement a validation layer for Python AST nodes
- [x] Accept only supported built-in Python constructs
- [x] Reject unsupported syntax with clear diagnostics

## What it accepts (the v1 subset)

Function definitions, typed scalar arguments, `int`/`float`/`bool` literals, single-target local assignments, arithmetic (`+ - * / // % **`), comparisons (including chained), boolean `and`/`or`, unary `+ - not`, `if`/`else`, `while`, `for ... in range(...)`, `return`, `pass`, and docstrings.

Everything else is rejected: classes, `async`, closures and globals, lambdas, containers and comprehensions, calls (except `range(...)` in a `for`), imports, exceptions, `with`, attribute access, subscripting, f-strings, walrus, `break`/`continue`, loop `else`, generic (PEP 695) functions, and `*args`/`**kwargs`/keyword-only/default parameters.

## How it works

`validate(extracted: ExtractedSource) -> None` raises `UnsupportedSyntaxError` carrying **one `Diagnostic` per rejected construct**, so a function with several problems reports all of them at once instead of one-per-run.

**Type-based dispatch.** The validator dispatches on node type with plum `@dispatch` (a single `visit` method overloaded per node type), matching the visitor convention used elsewhere in the Arx packages. The `ast.AST` overload is the fail-closed default: any node without an accepting overload is rejected, either with a specific message from a lookup table or a generic fallback, so unhandled or future syntax fails safe rather than passing silently. A rejected node's children are not descended into (one diagnostic per bad subtree), while independent sibling statements are each validated in full.

**Binding analysis.** `validate` collects the names bound in the function's **own** scope — parameters plus every assignment and loop target — and rejects any name read that is not bound, which is how closure captures and module globals are caught (an extracted nested function keeps its free variables as plain `Name` loads, so this cannot be done structurally). The collector deliberately does not descend into nested functions, lambdas, or classes: those have their own locals, and collecting them would both mask free-variable reads in this scope and misreport a nested binding as shadowing an outer name. A nested definition's own name does bind in the enclosing scope, so it is recorded while its body is skipped. The tuple, list, starred, annotated, augmented, and walrus binding forms are all recorded, so a statement the subset rejects does not additionally report a spurious free variable for the name it binds.

**`range` must really be `range`.** A `for` loop's iterable must be a call to the builtin `range` with 1–3 positional arguments and no keywords. Because only one of the three ways the name can be shadowed is visible in the AST, extraction preserves the defining module's namespace and the function's captured names, and validation rejects the loop when `range` resolves to:

| shadowed by | detected via |
|---|---|
| a local variable or argument | the binding analysis above |
| an enclosing function's variable (a closure capture) | the captured names (`co_freevars`) |
| a module-level name | the defining module's namespace vs `builtins.range` |

Each of those is a `TypeError` in Python when the shadowing value is not callable, so compiling them as the range intrinsic would silently disagree with the Python fallback.

**Locations.** Diagnostic columns are converted from ast's zero-based UTF-8 byte offsets to the one-based character contract from #95, and node line numbers are resolved against the real file — correctly for nested functions, where `node.lineno` is a real file line but the extracted source is indexed from its own first line.

## Scope of this PR

To keep review small, this PR is the validator plus a test set that exercises every code branch (100% coverage): the accept path, collect-all-at-once, real-file line/column correctness including a nested-function case, the binding and `range` rules, argument-shape rules, and the helpers. The **exhaustive one-test-per-unsupported-construct rejection matrix** lands in a small stacked follow-up — it is completeness coverage over the whitelist, and all of it routes through code paths already covered here.

## Design points to review

1. **Diagnostic `code` stays `None`.** I'd like to introduce a stable code scheme (e.g. `AJ001`) with this validation work, since it is the first stage emitting many distinct diagnostics — flagging for a decision on format/prefix before baking numbers in.
2. **Standalone expression statements are rejected** (a value computed and discarded), with docstrings and `pass` explicitly allowed; a bare `yield` is routed to the specific "generators are not supported" message.
3. **Loop `else` is rejected**, consistent with rejecting `break`: a loop `else` only runs when the loop exits without `break`, so accepting it would be dead code and would complicate lowering.
4. **`validate` takes `ExtractedSource`, returns `None`, raises on failure** — the fallback-vs-`strict` behavior belongs to the `@jit` wiring PR, not here.
5. **When the module namespace is unavailable** — only possible for a hand-built `ExtractedSource`, since `extract_source` always provides it for a real function — module-level shadowing cannot be observed and the name is taken to be the builtin. Happy to make that path stricter if you would rather it fail closed.

## Verification

- 39 validation tests (103 in arxjit), coverage 100%. Location assertions read this test file itself, so they don't rot when it is edited.
- The ast semantics relied on (byte-vs-character columns, `FunctionDef.lineno`, version-gated node types) were probed on CPython 3.10, 3.11, 3.13 and 3.14, and the binding, `range`-shadowing and generic-function rules were verified to behave identically on all four. `TryStar` (`except*`, 3.11+) and `type_params` (PEP 695, 3.12+) are both accessed through runtime guards, so the module imports on 3.10.
- All gates green locally: pytest + the 86% coverage gate, ruff format/check, mypy strict, bandit, vulture, mccabe, and `douki sync` idempotent.

## Note on the diff size

GitHub reports a large addition count because both files are new. Roughly half of it is mandatory Douki docstrings plus blank lines; the validator logic itself is about 250 lines, alongside a flat construct-to-message lookup table that reads as data.
