### PR TITLE
feat(arxjit): reject methods and make the rejection matrix exhaustive

### DIFF
--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -107,6 +107,24 @@ def _freevars_of(fn: PyFunc) -> frozenset[str]:
     return frozenset(getattr(code, "co_freevars", ()) or ())
 
 
+def _qualname_of(fn: PyFunc) -> str:
+    """
+    title: Return the qualified name a function was defined under.
+    summary: >-
+      Carried through extraction for the same reason as the module namespace: a
+      method is an ordinary function in the AST, and only __qualname__ records
+      the class it belongs to. Reads the unwrapped function so it matches the
+      retrieved source; empty for objects without a qualified name.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: str
+    """
+    qualname = getattr(_unwrapped(fn), "__qualname__", "")
+    return cast(str, qualname or "")
+
+
 def _name_of(fn: PyFunc) -> str:
     """
     title: Return a human-readable name for a function.
@@ -295,6 +313,13 @@ class ExtractedSource:
           The names the function captures from enclosing scopes, empty when it
           captures nothing. Carried for the same reason as ``globalns``: a
           captured name is indistinguishable from a builtin in the AST alone.
+      qualname:
+        type: str
+        description: >-
+          The function's __qualname__, or "" when the object has none. Carried
+          for the same reason as ``globalns``: a method is an ordinary function
+          in the AST, and only the qualified name records the class it was
+          defined in.
     """
 
     filename: str
@@ -305,6 +330,7 @@ class ExtractedSource:
         default=None, repr=False, compare=False
     )
     freevars: frozenset[str] = frozenset()
+    qualname: str = ""
 
 
 def extract_source(fn: PyFunc) -> ExtractedSource:
@@ -390,6 +416,7 @@ def extract_source(fn: PyFunc) -> ExtractedSource:
         node=node,
         globalns=_globals_of(fn),
         freevars=_freevars_of(fn),
+        qualname=_qualname_of(fn),
     )
 
 

--- a/packages/arxjit/src/arxjit/source.py
+++ b/packages/arxjit/src/arxjit/source.py
@@ -319,7 +319,9 @@ class ExtractedSource:
           The function's __qualname__, or "" when the object has none. Carried
           for the same reason as ``globalns``: a method is an ordinary function
           in the AST, and only the qualified name records the class it was
-          defined in.
+          defined in. It records the *definition site*, not which class owns
+          the descriptor now, so it cannot reveal a function assigned into a
+          class body or attached to a class afterwards.
     """
 
     filename: str

--- a/packages/arxjit/src/arxjit/validation.py
+++ b/packages/arxjit/src/arxjit/validation.py
@@ -168,17 +168,30 @@ def _diagnostic(
     )
 
 
-def _is_method(qualname: str) -> bool:
+def _defined_in_class_body(qualname: str) -> bool:
     """
-    title: Report whether a qualified name belongs to a class body.
-    summary: >-
-      A method is a function defined inside a class, which the extracted ast
-      alone cannot reveal: the decorated object is an ordinary function and its
-      first parameter is only conventionally named self. __qualname__ does
-      record it, as a dotted path whose second-to-last part is the owning
-      class. A function nested inside another function is also dotted, but
-      Python inserts the "<locals>" marker there, which distinguishes the two.
-      An empty qualname (a hand-built ExtractedSource) is not a method.
+    title: Report whether a function was lexically defined in a class body.
+    summary: |-
+      The extracted ast cannot reveal this on its own: the decorated object is
+      an ordinary function and its first parameter is only conventionally named
+      self. __qualname__ does record it, as a dotted path whose second-to-last
+      part is the owning class; a function nested inside another function is
+      dotted too, but Python inserts the "<locals>" marker there, which
+      distinguishes the two. An empty qualname (only reachable with a hand-
+      built ExtractedSource) is not a class body.
+      This is deliberately narrower than "is a method". __qualname__ records
+      where a function was defined, not whether a class currently owns the
+      descriptor, so three cases are outside the contract and validate cleanly:
+      a decorator that returns a different function without preserving
+      __qualname__ or setting __wrapped__, a function defined at module level
+      and assigned in a class body, and a function attached to a class after it
+      was created. Ownership is not knowable from source metadata. The first
+      two are reachable from the decorator layer, where
+      JitFunction.__set_name__ is called with the owning class for anything
+      bound in a class body; the third is not, because __set_name__ is only
+      called during class creation. A decorator chain that uses functools.wraps
+      stays covered here, because it copies __qualname__ and sets __wrapped__
+      for extraction to follow.
     parameters:
       qualname:
         type: str
@@ -737,26 +750,27 @@ def validate(extracted: ExtractedSource) -> None:
     """
     title: Validate that a function uses only the supported Python subset.
     summary: >-
-      Rejects methods, async definitions and generic (PEP 695) type parameters,
-      checks the argument shape, then walks the body collecting one diagnostic
-      per rejected construct, including free-variable reads (closures and
-      globals). A function with several unsupported constructs is reported in a
-      single UnsupportedSyntaxError carrying all of them, so a user fixes
-      everything in one pass.
+      Rejects functions defined in a class body, async definitions and generic
+      (PEP 695) type parameters, checks the argument shape, then walks the body
+      collecting one diagnostic per rejected construct, including free-variable
+      reads (closures and globals). A function with several unsupported
+      constructs is reported in a single UnsupportedSyntaxError carrying all of
+      them, so a user fixes everything in one pass. See _defined_in_class_body
+      for the method forms this cannot detect from source metadata alone.
     parameters:
       extracted:
         type: ExtractedSource
         description: The result of arxjit.source.extract_source.
     raises:
       UnsupportedSyntaxError: >-
-        If the function is a method, is async or generic, has an unsupported
-        argument shape, reads a free variable, or its body uses any construct
-        outside the v1 subset.
+        If the function is defined in a class body, is async or generic, has an
+        unsupported argument shape, reads a free variable, or its body uses any
+        construct outside the v1 subset.
     """
     node = extracted.node
     diagnostics: list[Diagnostic] = []
 
-    if _is_method(extracted.qualname):
+    if _defined_in_class_body(extracted.qualname):
         diagnostics.append(
             _diagnostic(
                 extracted,

--- a/packages/arxjit/src/arxjit/validation.py
+++ b/packages/arxjit/src/arxjit/validation.py
@@ -168,6 +168,27 @@ def _diagnostic(
     )
 
 
+def _is_method(qualname: str) -> bool:
+    """
+    title: Report whether a qualified name belongs to a class body.
+    summary: >-
+      A method is a function defined inside a class, which the extracted ast
+      alone cannot reveal: the decorated object is an ordinary function and its
+      first parameter is only conventionally named self. __qualname__ does
+      record it, as a dotted path whose second-to-last part is the owning
+      class. A function nested inside another function is also dotted, but
+      Python inserts the "<locals>" marker there, which distinguishes the two.
+      An empty qualname (a hand-built ExtractedSource) is not a method.
+    parameters:
+      qualname:
+        type: str
+    returns:
+      type: bool
+    """
+    parts = qualname.split(".")
+    return len(parts) > 1 and parts[-2] != "<locals>"
+
+
 def _target_names(target: ast.expr) -> set[str]:
     """
     title: Collect the names bound by an assignment or loop target.
@@ -716,25 +737,33 @@ def validate(extracted: ExtractedSource) -> None:
     """
     title: Validate that a function uses only the supported Python subset.
     summary: >-
-      Rejects async definitions and generic (PEP 695) type parameters, checks
-      the argument shape, then walks the body collecting one diagnostic per
-      rejected construct, including free-variable reads (closures and globals).
-      A function with several unsupported constructs is reported in a single
-      UnsupportedSyntaxError carrying all of them, so a user fixes everything
-      in one pass.
+      Rejects methods, async definitions and generic (PEP 695) type parameters,
+      checks the argument shape, then walks the body collecting one diagnostic
+      per rejected construct, including free-variable reads (closures and
+      globals). A function with several unsupported constructs is reported in a
+      single UnsupportedSyntaxError carrying all of them, so a user fixes
+      everything in one pass.
     parameters:
       extracted:
         type: ExtractedSource
         description: The result of arxjit.source.extract_source.
     raises:
       UnsupportedSyntaxError: >-
-        If the function is async or generic, has an unsupported argument shape,
-        reads a free variable, or its body uses any construct outside the v1
-        subset.
+        If the function is a method, is async or generic, has an unsupported
+        argument shape, reads a free variable, or its body uses any construct
+        outside the v1 subset.
     """
     node = extracted.node
     diagnostics: list[Diagnostic] = []
 
+    if _is_method(extracted.qualname):
+        diagnostics.append(
+            _diagnostic(
+                extracted,
+                node,
+                "methods are not supported (only module-level functions)",
+            )
+        )
     if isinstance(node, ast.AsyncFunctionDef):
         diagnostics.append(
             _diagnostic(

--- a/packages/arxjit/tests/test_source.py
+++ b/packages/arxjit/tests/test_source.py
@@ -848,6 +848,34 @@ def test_namespace_is_excluded_from_repr_and_equality() -> None:
     assert extracted == dataclasses.replace(extracted, globalns={"x": 1})
 
 
+def test_qualified_name_is_carried() -> None:
+    """
+    title: Extraction records the function's qualified name.
+    summary: >-
+      A method and a module-level function are indistinguishable in the
+      extracted ast, so validation needs the qualified name to tell them apart.
+    """
+
+    class Calc:
+        """
+        title: Hold a method to extract (test helper).
+        """
+
+        def scaled(self, x: int) -> int:
+            """
+            title: Double the argument.
+            parameters:
+              x:
+                type: int
+            returns:
+              type: int
+            """
+            return x * 2
+
+    assert extract_source(sample_add).qualname == "sample_add"
+    assert extract_source(Calc.scaled).qualname.endswith("Calc.scaled")
+
+
 def test_extracted_source_is_frozen() -> None:
     """
     title: ExtractedSource instances are immutable.

--- a/packages/arxjit/tests/test_validation.py
+++ b/packages/arxjit/tests/test_validation.py
@@ -3,6 +3,7 @@ title: Tests for Python-subset validation.
 """
 
 import ast
+import functools
 
 from typing import Any, Callable
 
@@ -1053,29 +1054,196 @@ def test_generic_function_is_rejected() -> None:
     )
 
 
-def test_method_is_rejected() -> None:
+def sample_module_level(self: Any, x: int) -> int:
     """
-    title: A function defined in a class body is rejected as a method.
+    title: Double the argument (test helper defined outside any class).
+    parameters:
+      self:
+        type: Any
+      x:
+        type: int
+    returns:
+      type: int
+    """
+    return x * 2
+
+
+def _wraps_preserving(fn: PyFunc) -> PyFunc:
+    """
+    title: Replace a function, preserving its identity metadata.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: PyFunc
     """
 
-    class Calc:
+    @functools.wraps(fn)
+    def inner(self: Any, x: int) -> int:
         """
-        title: Hold a method to validate (test helper).
+        title: Double the argument.
+        parameters:
+          self:
+            type: Any
+          x:
+            type: int
+        returns:
+          type: int
         """
+        return x * 2
 
-        def scaled(self, x: int) -> int:
-            """
-            title: Double the argument.
-            parameters:
-              x:
-                type: int
-            returns:
-              type: int
-            """
-            return x * 2
+    return inner
 
-    (diagnostic,) = _rejected(Calc.scaled)
+
+def _replacing(fn: PyFunc) -> PyFunc:
+    """
+    title: Replace a function without preserving its identity metadata.
+    parameters:
+      fn:
+        type: PyFunc
+    returns:
+      type: PyFunc
+    """
+
+    def replacement(self: Any, x: int) -> int:
+        """
+        title: Double the argument.
+        parameters:
+          self:
+            type: Any
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * 2
+
+    return replacement
+
+
+class SampleCalc:
+    """
+    title: Hold every method form to validate (test helper).
+    """
+
+    def scaled(self, x: int) -> int:
+        """
+        title: Double the argument.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * 2
+
+    @staticmethod
+    def stat(x: int) -> int:
+        """
+        title: Double the argument, without an instance.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * 2
+
+    @classmethod
+    def klass(cls, x: int) -> int:
+        """
+        title: Double the argument, given the class.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * 2
+
+    @_wraps_preserving
+    def wrapped(self, x: int) -> int:
+        """
+        title: Double the argument, behind a functools.wraps decorator.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * 2
+
+    assigned = sample_module_level
+
+
+class SampleCalc2:
+    """
+    title: Hold a method replaced by a non-wraps decorator (test helper).
+    """
+
+    @_replacing
+    def replaced(self, x: int) -> int:
+        """
+        title: Return the argument unchanged.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x
+
+
+@pytest.mark.parametrize(
+    "attribute",
+    ["scaled", "stat", "klass", "wrapped"],
+)
+def test_method_is_rejected(attribute: str) -> None:
+    """
+    title: Every method form defined in a class body is rejected.
+    summary: >-
+      An instance method and a staticmethod resolve to plain functions when
+      accessed through the class, while a classmethod resolves to a bound
+      method object, so all three are pinned rather than assumed equivalent. A
+      functools.wraps decorator chain stays covered because it copies
+      __qualname__ and sets __wrapped__ for extraction to follow.
+    parameters:
+      attribute:
+        type: str
+    """
+    (diagnostic,) = _rejected(getattr(SampleCalc, attribute))
     assert "methods are not supported" in diagnostic.message
+
+
+def test_class_body_assignment_is_not_detected() -> None:
+    """
+    title: A module-level function assigned in a class body is accepted.
+    summary: >-
+      Documented limitation rather than an oversight: SampleCalc.assigned is a
+      genuine method, but __qualname__ records where the function was defined,
+      so nothing in the extracted source or its metadata reveals the class that
+      now owns it. Closing this needs the decorator layer, where
+      JitFunction.__set_name__ receives the owning class. Pinned so the
+      contract is explicit and a future fix has a test to flip.
+    """
+    extracted = extract_source(SampleCalc.assigned)
+    assert extracted.qualname == "sample_module_level"
+    validate(extracted)
+
+
+def test_decorator_dropping_qualname_is_not_detected() -> None:
+    """
+    title: A method behind a non-wraps decorator is accepted.
+    summary: >-
+      The second documented limitation: a decorator that returns a different
+      function without functools.wraps preserves neither __qualname__ nor
+      __wrapped__, so the replacement reports the decorator's own scope and
+      extraction has no chain to follow back. Pinned for the same reason as the
+      assignment case.
+    """
+    extracted = extract_source(SampleCalc2.replaced)
+    assert extracted.qualname.endswith("<locals>.replacement")
+    validate(extracted)
 
 
 def test_nested_function_is_not_treated_as_a_method() -> None:

--- a/packages/arxjit/tests/test_validation.py
+++ b/packages/arxjit/tests/test_validation.py
@@ -12,6 +12,7 @@ from arxjit.diagnostics import DiagnosticSeverity
 from arxjit.errors import UnsupportedSyntaxError
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.validation import (
+    _UNSUPPORTED_MESSAGES,
     _bound_names,
     _char_column,
     _SubsetValidator,
@@ -19,6 +20,10 @@ from arxjit.validation import (
 )
 
 PyFunc = Callable[..., Any]
+
+# except* parses only on Python 3.11+; the validator guards its table entry
+# the same way, so the matrix below has to agree with whichever it is.
+_TRY_STAR = getattr(ast, "TryStar", None)
 
 
 def _rejected(fn: PyFunc) -> list[Any]:
@@ -1046,6 +1051,231 @@ def test_generic_function_is_rejected() -> None:
     assert any(
         "generic functions" in d.message for d in caught.value.diagnostics
     )
+
+
+def test_method_is_rejected() -> None:
+    """
+    title: A function defined in a class body is rejected as a method.
+    """
+
+    class Calc:
+        """
+        title: Hold a method to validate (test helper).
+        """
+
+        def scaled(self, x: int) -> int:
+            """
+            title: Double the argument.
+            parameters:
+              x:
+                type: int
+            returns:
+              type: int
+            """
+            return x * 2
+
+    (diagnostic,) = _rejected(Calc.scaled)
+    assert "methods are not supported" in diagnostic.message
+
+
+def test_nested_function_is_not_treated_as_a_method() -> None:
+    """
+    title: A function nested in another function is not a method.
+    summary: >-
+      Both are dotted qualified names; only a method's has a class as its
+      second-to-last part, where a nested function has "<locals>".
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Double the argument.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x * 2
+
+    assert "<locals>" in sample.__qualname__
+    validate(extract_source(sample))
+
+
+# Every construct outside the v1 subset, paired with the smallest function
+# body that produces it. The parametrized test below asserts each one is
+# routed to its own entry in _UNSUPPORTED_MESSAGES rather than to a more
+# general one, and test_every_unsupported_message_has_a_case asserts this
+# list stays exhaustive as the table grows.
+_UNSUPPORTED_CASES: list[tuple[type[ast.AST], str]] = [
+    (ast.ClassDef, "class C:\n    pass"),
+    (ast.Lambda, "f = lambda: 1"),
+    (ast.FunctionDef, "def inner():\n    return 1"),
+    (ast.AsyncFunctionDef, "async def inner():\n    return 1"),
+    (ast.AsyncFor, "async for i in x:\n    pass"),
+    (ast.AsyncWith, "async with x:\n    pass"),
+    (ast.With, "with x:\n    pass"),
+    (ast.Try, "try:\n    pass\nexcept Exception:\n    pass"),
+    (ast.Raise, "raise ValueError"),
+    (ast.Assert, "assert x"),
+    (ast.Import, "import math"),
+    (ast.ImportFrom, "from math import sqrt"),
+    (ast.Global, "global g"),
+    (ast.Nonlocal, "nonlocal n"),
+    (ast.Yield, "yield x"),
+    (ast.YieldFrom, "yield from x"),
+    (ast.List, "v = [1]"),
+    (ast.Dict, "v = {1: 2}"),
+    (ast.Set, "v = {1}"),
+    (ast.Tuple, "v = (1, 2)"),
+    (ast.ListComp, "v = [i for i in range(x)]"),
+    (ast.DictComp, "v = {i: i for i in range(x)}"),
+    (ast.SetComp, "v = {i for i in range(x)}"),
+    (ast.GeneratorExp, "v = (i for i in range(x))"),
+    (ast.Break, "while x:\n    break"),
+    (ast.Continue, "while x:\n    continue"),
+    (ast.Delete, "del x"),
+    (ast.AnnAssign, "v: int = 1"),
+    (ast.AugAssign, "x += 1"),
+    (ast.JoinedStr, 'v = f"{x}"'),
+    (ast.NamedExpr, "if (v := x):\n    pass"),
+    (ast.Attribute, "v = x.real"),
+    (ast.Subscript, "v = x[0]"),
+    (ast.Match, "match x:\n    case 1:\n        pass"),
+    # Await and Starred are shadowed in the positions one reaches for first:
+    # a bare "await x" is an expression statement and "[*x]" is a list
+    # literal, so each reports the enclosing construct instead. These are the
+    # positions where the node itself is what gets rejected.
+    (ast.Await, "v = await x"),
+    (ast.Starred, "for i in range(*x):\n    pass"),
+]
+
+if _TRY_STAR is not None:  # pragma: no cover - version dependent
+    _UNSUPPORTED_CASES.append(
+        (_TRY_STAR, "try:\n    pass\nexcept* Exception:\n    pass")
+    )
+
+# ast.Slice has a message in the table but no reachable position: a slice can
+# only appear inside a Subscript, and Subscript is rejected without descending
+# into it. The entry is kept as a safety net in case that ever changes, and is
+# named here so the exhaustiveness test stays honest about it.
+_SHADOWED_MESSAGES: frozenset[type[ast.AST]] = frozenset({ast.Slice})
+
+_ASYNC_ONLY: tuple[type[ast.AST], ...] = (
+    ast.Await,
+    ast.AsyncFor,
+    ast.AsyncWith,
+)
+
+
+def _validate_snippet(body: str, is_async: bool = False) -> list[str]:
+    """
+    title: Validate a function built around a body snippet (test helper).
+    summary: >-
+      Builds the smallest function containing the snippet, hand-constructs an
+      ExtractedSource around it, and returns the rejection messages. The source
+      is built as text rather than as a real nested function so that a lint
+      autofix cannot rewrite the construct under test, which has happened
+      before with unused in-function imports.
+    parameters:
+      body:
+        type: str
+        description: The statements to place in the function body.
+      is_async:
+        type: bool
+        description: Whether the containing function must be async.
+    returns:
+      type: list[str]
+    """
+    prefix = "async def" if is_async else "def"
+    indented = "\n".join(
+        f"    {line}" if line else "" for line in body.splitlines()
+    )
+    source = f"{prefix} sample(x: int) -> int:\n{indented}\n    return x\n"
+    node = ast.parse(source).body[0]
+    assert isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    extracted = ExtractedSource(
+        filename="<test>", source=source, lineno=1, node=node
+    )
+    with pytest.raises(UnsupportedSyntaxError) as caught:
+        validate(extracted)
+    return [d.message for d in caught.value.diagnostics]
+
+
+@pytest.mark.parametrize(
+    ("node_type", "body"),
+    _UNSUPPORTED_CASES,
+    ids=[node_type.__name__ for node_type, _ in _UNSUPPORTED_CASES],
+)
+def test_unsupported_construct_uses_its_own_message(
+    node_type: type[ast.AST],
+    body: str,
+) -> None:
+    """
+    title: Every unsupported construct reports its own diagnostic message.
+    summary: >-
+      Guards against a construct being swallowed by a more general rule: the
+      message produced must be the one the table assigns to that node type, not
+      one belonging to an enclosing node.
+    parameters:
+      node_type:
+        type: type[ast.AST]
+      body:
+        type: str
+    """
+    messages = _validate_snippet(body, is_async=node_type in _ASYNC_ONLY)
+    assert _UNSUPPORTED_MESSAGES[node_type] in messages
+
+
+def test_every_unsupported_message_has_a_case() -> None:
+    """
+    title: The rejection matrix covers every entry in the message table.
+    summary: >-
+      Adding a message to _UNSUPPORTED_MESSAGES without a matching case here
+      fails this test, so the matrix cannot quietly fall behind the validator.
+    """
+    covered = {node_type for node_type, _ in _UNSUPPORTED_CASES}
+    assert covered | _SHADOWED_MESSAGES == set(_UNSUPPORTED_MESSAGES)
+
+
+def test_walrus_does_not_also_report_a_free_variable() -> None:
+    """
+    title: A rejected walrus binds its name, so it reports exactly once.
+    summary: >-
+      The binding collector records NamedExpr targets precisely so a rejected
+      statement does not also emit a spurious free-variable read for the name
+      it introduces.
+    """
+    messages = _validate_snippet("if (v := x):\n    pass\nv = v + 1")
+    assert messages == ["walrus assignment expressions are not supported"]
+
+
+def test_annotated_assignment_does_not_also_report_a_free_variable() -> None:
+    """
+    title: A rejected annotated assignment binds its target.
+    """
+    messages = _validate_snippet("v: int = 1\nv = v + 1")
+    assert messages == ["annotated assignments are not supported"]
+
+
+def test_augmented_assignment_does_not_also_report_a_free_variable() -> None:
+    """
+    title: A rejected augmented assignment binds its target.
+    """
+    messages = _validate_snippet("v = 1\nv += 1\nv = v + 1")
+    assert messages == ["augmented assignment (e.g. +=) is not supported"]
+
+
+def test_call_nested_inside_range_args_is_rejected() -> None:
+    """
+    title: A non-range call inside range(...)'s arguments is rejected.
+    summary: >-
+      range() itself is the one permitted call, so its arguments still have to
+      be walked rather than trusted.
+    """
+    messages = _validate_snippet("for i in range(abs(x)):\n    pass")
+    assert messages == [
+        "calling functions is not supported (only range() in a for loop)"
+    ]
 
 
 _SAMPLE_GLOBAL = 2


### PR DESCRIPTION
Continues the validation work from #99.

## Methods defined in a class body were accepted

Wiki Issue 4 lists methods among the initial unsupported constructs, but nothing caught them. A method is an ordinary function in the extracted ast, and its first parameter is only conventionally named `self`, so all forms validated cleanly. Extraction now carries `__qualname__` on `ExtractedSource` (the same rationale as `globalns` and `freevars`: runtime context the ast cannot supply) and validation uses it. A function nested inside another function is dotted too, but Python inserts the `<locals>` marker there, which distinguishes the two.

## Scope of the check — narrowed after review

`__qualname__` records where a function was *defined*, not whether a class currently owns the descriptor. The check is therefore deliberately named `_defined_in_class_body` rather than `_is_method`, and the contract is documented on the predicate, on the `qualname` field, and on `validate`. Measured boundary:

| case | `__qualname__` | validates? |
|---|---|---|
| instance method | `Calc.scaled` | rejected |
| staticmethod | `Calc.stat` | rejected |
| classmethod (bound method object) | `Calc.klass` | rejected |
| `functools.wraps` decorator chain | `Calc.wrapped` | rejected |
| decorator dropping `__qualname__`/`__wrapped__` | `replacement.<locals>.wrapped` | **accepted** |
| module-level function assigned in a class body | `sample_module_level` | **accepted** |
| function attached to a class after creation | `sample_module_level` | **accepted** |

All four detected forms are pinned by a parametrized test — the classmethod matters separately because it resolves to a bound method object rather than a function. The three undetected cases are pinned too, as accepted, with the reason in the test docstring, so the contract is explicit and a future fix has a test to flip.

**Follow-up, verified not assumed:** I checked on 3.10/3.11/3.14 that `__set_name__` is called for anything bound in a class body, *including* a decorator's return value — so the `@jit` layer can close the first two cases by carrying the owning class. It is **not** called for assignment after class creation, so that case stays undetectable at any layer. This lands in the wiring PR, which is where `core.py` gets touched; this PR does not modify the decorator. One wrinkle recorded for it: an exception raised from `__set_name__` is wrapped in `RuntimeError` on 3.10/3.11 but propagates bare on 3.12+, which `strict=True` will have to account for.

Not covered here for the same reason: the `@jit` + `@staticmethod`/`@classmethod` decorator-order combinations, which need the decorator.

## The rejection matrix is now table-driven and exhaustive

The per-construct rejection tests are replaced by a matrix over `_UNSUPPORTED_MESSAGES`, plus a test asserting the matrix covers every entry in the table, so it cannot quietly fall behind the validator (wiki Issue 12, "tests for unsupported syntax diagnostics"). Each case asserts the construct reports *its own* message rather than one belonging to an enclosing node.

That check immediately found three entries whose message was shadowed:

| Entry | In the obvious position | Reachable? |
|---|---|---|
| `ast.Await` | `await x` reports *"standalone expression statements"* | yes, as `v = await x` |
| `ast.Starred` | `v = [*x]` reports *"list literals"* | yes, as `range(*x)` |
| `ast.Slice` | `x[0:1]` reports *"subscripting"* | **no reachable position found** |

`Subscript` and the container types reject without descending, so their children's messages are unreachable. On severity: every one of these constructs *is* still rejected, just with a less specific message — message quality plus one dead table entry, not a correctness hole.

The first two are now exercised in the positions that reach them. **Design point:** `ast.Slice` is kept as a safety net and named in `_SHADOWED_MESSAGES` so the exhaustiveness test stays honest, rather than silently deleted. Happy to drop the entry instead if you'd prefer the table to contain only reachable messages.

The matrix builds its sources as text rather than as real nested functions, so a lint autofix cannot rewrite the construct under test — that happened previously with unused in-function imports being stripped by `ruff --fix`, leaving tests validating the wrong source.

## Verification

153 tests, arxjit coverage 100%. All gates green locally: pytest+cov, ruff format/check, mypy strict (`cd packages/arxjit && mypy src`), bandit `-iii -lll`, vulture 80, mccabe 10, `douki sync` idempotent.

Verified on CPython 3.10.19, 3.11.11 and 3.14.6. The `TryStar` case is version-gated the same way the validator guards its table entry, and appears only on 3.11+.