### PR TITLE
feat(arxjit): resolve a compilable signature from Python annotations

### DIFF
--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -11,6 +11,7 @@ from arxjit.errors import (
     SourceExtractionError,
     UnsupportedSyntaxError,
 )
+from arxjit.reconcile import resolve_signature
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.types import (
     Signature,
@@ -61,5 +62,6 @@ __all__ = [
     "i32",
     "i64",
     "jit",
+    "resolve_signature",
     "validate",
 ]

--- a/packages/arxjit/src/arxjit/locations.py
+++ b/packages/arxjit/src/arxjit/locations.py
@@ -1,0 +1,90 @@
+"""
+title: Source-location helpers shared by the arxjit pipeline stages.
+summary: >-
+  Every stage that reports a problem against a parsed function has to turn an
+  ast node back into a Diagnostic pointing at the user's real source. Both the
+  conversion from ast's zero-based UTF-8 byte columns to the one-based Unicode
+  character columns Diagnostic documents, and the mapping from a node's file
+  line back into the extracted source text, live here so the validation and
+  signature stages cannot drift apart on the column contract.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.source import ExtractedSource
+
+
+def char_column(line: str, byte_offset: int) -> int:
+    """
+    title: Convert a zero-based UTF-8 byte offset to a one-based column.
+    summary: >-
+      ast column offsets are zero-based UTF-8 byte offsets into their source
+      line, but Diagnostic.column is documented as a one-based Unicode
+      character column. Decoding the byte prefix back to text and measuring its
+      length performs the conversion exactly, including when multi-byte
+      characters appear before the target column.
+    parameters:
+      line:
+        type: str
+        description: The real source line the offset was reported against.
+      byte_offset:
+        type: int
+    returns:
+      type: int
+    """
+    prefix = line.encode("utf-8")[:byte_offset]
+    return len(prefix.decode("utf-8", errors="replace")) + 1
+
+
+def diagnostic(
+    extracted: ExtractedSource,
+    node: ast.AST,
+    message: str,
+    severity: DiagnosticSeverity = DiagnosticSeverity.ERROR,
+) -> Diagnostic:
+    """
+    title: Build a diagnostic located at an ast node.
+    summary: >-
+      Reads the node's lineno/col_offset when present and converts the column
+      to the one-based character contract via char_column; falls back to no
+      location when the node carries none. node.lineno is a real file line
+      number (extract_source already shifted it), while extracted.source is
+      indexed from its own first line, so the node's line is looked up at
+      splitlines()[lineno - extracted.lineno] rather than lineno - 1.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      node:
+        type: ast.AST
+      message:
+        type: str
+      severity:
+        type: DiagnosticSeverity
+        description: Defaults to ERROR, the severity of a rejection.
+    returns:
+      type: Diagnostic
+    """
+    lineno = getattr(node, "lineno", None)
+    col_offset = getattr(node, "col_offset", None)
+    column = None
+    if lineno is not None and col_offset is not None:
+        lines = extracted.source.splitlines()
+        index = lineno - extracted.lineno
+        if 0 <= index < len(lines):
+            column = char_column(lines[index], col_offset)
+    return Diagnostic(
+        severity=severity,
+        message=message,
+        filename=extracted.filename,
+        line=lineno,
+        column=column,
+    )
+
+
+__all__ = [
+    "char_column",
+    "diagnostic",
+]

--- a/packages/arxjit/src/arxjit/reconcile.py
+++ b/packages/arxjit/src/arxjit/reconcile.py
@@ -14,6 +14,7 @@ summary: >-
 from __future__ import annotations
 
 import ast
+import builtins
 
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
 from arxjit.locations import diagnostic
@@ -90,23 +91,144 @@ def _unsupported_shape(
     ]
 
 
-def _annotation_type(annotation: ast.expr | None) -> SigType | None:
+def _arity_mismatch(
+    extracted: ExtractedSource,
+    explicit: Signature,
+) -> list[Diagnostic]:
     """
-    title: Map an annotation expression to a supported scalar type.
+    title: Reject an explicit signature that describes a different function.
     summary: >-
-      Only a bare name is accepted, which is what int, float and bool parse to.
-      Anything else (a subscript such as list[int], an attribute such as
-      np.float64, a string, or an alias bound to a supported builtin) yields
-      None, so the caller reports it against the annotation's own location.
+      An explicit signature overrides which *types* the compiler uses, because
+      that is a choice the caller is entitled to make. How many parameters the
+      function has is not a choice: it is a fact of the definition, readable
+      without consulting a single annotation. A signature that disagrees would
+      compile to a calling convention Python cannot satisfy, so it is rejected
+      rather than trusted.
     parameters:
+      extracted:
+        type: ExtractedSource
+      explicit:
+        type: Signature
+    returns:
+      type: list[Diagnostic]
+    """
+    declared = len(explicit.arg_types)
+    actual = len(_parameters(extracted.node.args))
+    if declared == actual:
+        return []
+    plural = "" if declared == 1 else "s"
+    return [
+        diagnostic(
+            extracted,
+            extracted.node,
+            f"signature declares {declared} argument{plural} but"
+            f" {extracted.node.name!r} takes {actual}",
+        )
+    ]
+
+
+def _structural_diagnostics(
+    extracted: ExtractedSource,
+    explicit: Signature | None,
+) -> list[Diagnostic]:
+    """
+    title: Check the facts about a function that no signature may override.
+    summary: >-
+      Runs before the explicit signature is accepted, so both paths are held to
+      the same structural rules. An explicit signature decides types only; the
+      argument shape and the number of parameters are read from the definition
+      and are not the caller's to restate differently. An unsupported shape
+      stops the check there: counting the positional parameters of a function
+      that also takes *args would report a count no caller could act on.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      explicit:
+        type: Signature | None
+    returns:
+      type: list[Diagnostic]
+    """
+    shape = _unsupported_shape(extracted, extracted.node.args)
+    if shape:
+        return shape
+    if explicit is None:
+        return []
+    return _arity_mismatch(extracted, explicit)
+
+
+def _annotation_shadow(
+    extracted: ExtractedSource,
+    name: str,
+) -> str | None:
+    """
+    title: Return what shadows a builtin annotation name, or None.
+    summary: >-
+      An annotation is matched by spelling, so ``int`` must still resolve to
+      builtins.int for that match to mean anything; rebinding the name makes
+      the annotation denote something else entirely. Only the defining module's
+      namespace is consulted. A function's own locals cannot apply, because
+      annotations are evaluated in the enclosing scope when the def executes,
+      and an enclosing function's rebinding is not observable here: freevars
+      records only the names the body reads, and an annotation is not part of
+      the body. When the namespace is unavailable (only for a hand-built
+      ExtractedSource; extract_source always provides it for a real function)
+      shadowing cannot be observed and the name is taken to be the builtin,
+      matching how validation treats a shadowed range.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      name:
+        type: str
+    returns:
+      type: str | None
+    """
+    namespace = extracted.globalns
+    if namespace is None:
+        return None
+    # Every key of _ANNOTATION_TYPES names a builtin, and this is only
+    # reached for a name already found there, so the lookup cannot fail. A
+    # default would be worse than an error: with one, a name absent from
+    # builtins would compare unequal to itself and report every module that
+    # merely defines it as shadowing.
+    builtin = getattr(builtins, name)
+    if namespace.get(name, builtin) is not builtin:
+        return "a module-level name"
+    return None
+
+
+def _resolve_annotation(
+    extracted: ExtractedSource,
+    annotation: ast.expr | None,
+) -> tuple[SigType | None, str | None]:
+    """
+    title: Resolve an annotation to a scalar type, or say why it cannot be.
+    summary: >-
+      Returns the type and no reason, or no type and the reason to report. An
+      annotation has to clear two hurdles: it must be a bare name this package
+      maps, and that name must still refer to the builtin it is spelled after.
+      Only a bare name is accepted, which is what int, float and bool parse to;
+      anything else (a subscript such as list[int], an attribute such as
+      np.float64, or a string) is refused against its own location.
+    parameters:
+      extracted:
+        type: ExtractedSource
       annotation:
         type: ast.expr | None
     returns:
-      type: SigType | None
+      type: tuple[SigType | None, str | None]
     """
     if not isinstance(annotation, ast.Name):
-        return None
-    return _ANNOTATION_TYPES.get(annotation.id)
+        return None, _SUPPORTED
+    sig_type = _ANNOTATION_TYPES.get(annotation.id)
+    if sig_type is None:
+        return None, _SUPPORTED
+    shadow = _annotation_shadow(extracted, annotation.id)
+    if shadow is not None:
+        return None, (
+            f"{annotation.id!r} is bound to {shadow} here, so it does not"
+            " refer to the builtin"
+        )
+    return sig_type, None
 
 
 def _argument_types(
@@ -140,14 +262,14 @@ def _argument_types(
                 )
             )
             continue
-        arg_type = _annotation_type(parameter.annotation)
+        arg_type, reason = _resolve_annotation(extracted, parameter.annotation)
         if arg_type is None:
             diagnostics.append(
                 diagnostic(
                     extracted,
                     parameter.annotation,
                     f"unsupported type annotation for parameter"
-                    f" {parameter.arg!r}: {_SUPPORTED}",
+                    f" {parameter.arg!r}: {reason}",
                 )
             )
             continue
@@ -175,13 +297,13 @@ def _return_type(
                 f"{node.name!r} has no return type annotation",
             )
         ]
-    return_type = _annotation_type(node.returns)
+    return_type, reason = _resolve_annotation(extracted, node.returns)
     if return_type is None:
         return None, [
             diagnostic(
                 extracted,
                 node.returns,
-                f"unsupported return type annotation: {_SUPPORTED}",
+                f"unsupported return type annotation: {reason}",
             )
         ]
     return return_type, []
@@ -206,10 +328,6 @@ def _from_annotations(
       type: tuple[Signature | None, list[Diagnostic]]
     """
     node = extracted.node
-    shape = _unsupported_shape(extracted, node.args)
-    if shape:
-        return None, shape
-
     parameters = _parameters(node.args)
     annotated = any(p.annotation is not None for p in parameters)
     if not annotated and node.returns is None:
@@ -238,12 +356,16 @@ def resolve_signature(
     """
     title: Decide the Signature a validated function compiles against.
     summary: >-
-      An explicit signature wins outright and the annotations are not even
-      read, so a function may annotate freely (or not at all) without having to
-      agree with it; there is deliberately no mismatch error. Without one, the
-      annotations are used. The returned signature is None exactly when the
-      returned diagnostics are non-empty, which is the caller's signal that the
-      function cannot be compiled.
+      An explicit signature decides the argument and return *types* outright
+      and the annotations are not even read, so a function may annotate freely
+      (or not at all) without having to agree with it; there is deliberately no
+      type-mismatch error. It does not override the structure of the
+      definition: the argument shape and the number of parameters are checked
+      against the function first, on both paths, because those are facts rather
+      than choices. Without an explicit signature, the annotations are used.
+      The returned signature is None exactly when the returned diagnostics are
+      non-empty, which is the caller's signal that the function cannot be
+      compiled.
     parameters:
       extracted:
         type: ExtractedSource
@@ -254,6 +376,9 @@ def resolve_signature(
     returns:
       type: tuple[Signature | None, list[Diagnostic]]
     """
+    structural = _structural_diagnostics(extracted, explicit)
+    if structural:
+        return None, structural
     if explicit is not None:
         return explicit, []
     return _from_annotations(extracted)

--- a/packages/arxjit/src/arxjit/reconcile.py
+++ b/packages/arxjit/src/arxjit/reconcile.py
@@ -8,13 +8,17 @@ summary: >-
   and stays interpreted. Annotations are read from the ast rather than from
   __annotations__ so that a module using "from __future__ import annotations"
   behaves identically, and so every diagnostic can point at the exact
-  annotation that caused it.
+  annotation that caused it. Following from that, ``int``, ``float`` and
+  ``bool`` are reserved annotation spellings in a @jit function: they select
+  i64, f64 and bool_ by name, independently of Python name resolution, so what
+  those names are bound to where the function was defined does not change what
+  the compiler is asked for. See _annotation_type for why resolving them
+  through the defining namespace cannot be made sound.
 """
 
 from __future__ import annotations
 
 import ast
-import builtins
 
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
 from arxjit.locations import diagnostic
@@ -156,87 +160,43 @@ def _structural_diagnostics(
     return _arity_mismatch(extracted, explicit)
 
 
-def _annotation_shadow(
-    extracted: ExtractedSource,
-    name: str,
-) -> str | None:
+def _annotation_type(annotation: ast.expr | None) -> SigType | None:
     """
-    title: Return what shadows a builtin annotation name, or None.
+    title: Map an annotation to a scalar type by its spelling.
     summary: |-
-      An annotation is matched by spelling, so ``int`` must still resolve to
-      builtins.int for that match to mean anything; rebinding the name makes
-      the annotation denote something else entirely. Only the defining module's
-      namespace is consulted. A function's own locals cannot apply, because
-      annotations are evaluated in the enclosing scope when the def executes.
-      When the namespace is unavailable (only for a hand-built ExtractedSource;
-      extract_source always provides it for a real function) shadowing cannot
-      be observed and the name is taken to be the builtin, matching how
-      validation treats a shadowed range.
-      Rebinding by an enclosing *function* is a documented limitation: such a
-      function derives a signature from the builtin its annotation is spelled
-      after, with no diagnostic, even though the annotation denotes the rebound
-      value. Nothing extraction carries can reveal it, because the binding is
-      not a module global and freevars records only the names the body reads,
-      which an annotation is not. Reading __annotations__ instead would not
-      settle it: under "from __future__ import annotations" they hold strings,
-      and inspect.get_annotations(eval_str=True) evaluates those against
-      __globals__, which cannot see an enclosing scope, so it answers with the
-      builtin on every supported CPython.
-    parameters:
-      extracted:
-        type: ExtractedSource
-      name:
-        type: str
-    returns:
-      type: str | None
-    """
-    namespace = extracted.globalns
-    if namespace is None:
-        return None
-    # Every key of _ANNOTATION_TYPES names a builtin, and this is only
-    # reached for a name already found there, so the lookup cannot fail. A
-    # default would be worse than an error: with one, a name absent from
-    # builtins would compare unequal to itself and report every module that
-    # merely defines it as shadowing.
-    builtin = getattr(builtins, name)
-    if namespace.get(name, builtin) is not builtin:
-        return "a module-level name"
-    return None
+      ``int``, ``float`` and ``bool`` are reserved annotation spellings in a
+      @jit function: they always denote i64, f64 and bool_, whatever those
+      names happen to be bound to where the function was defined. Only a bare
+      name is accepted, which is what they parse to; anything structural (a
+      subscript such as list[int], an attribute such as np.float64, or a
+      string) yields None so the caller reports it against its own location.
 
-
-def _resolve_annotation(
-    extracted: ExtractedSource,
-    annotation: ast.expr | None,
-) -> tuple[SigType | None, str | None]:
-    """
-    title: Resolve an annotation to a scalar type, or say why it cannot be.
-    summary: >-
-      Returns the type and no reason, or no type and the reason to report. An
-      annotation has to clear two hurdles: it must be a bare name this package
-      maps, and that name must still refer to the builtin it is spelled after.
-      Only a bare name is accepted, which is what int, float and bool parse to;
-      anything else (a subscript such as list[int], an attribute such as
-      np.float64, or a string) is refused against its own location.
+      Resolving the name through the defining namespace instead was tried and
+      cannot be made sound. A function's __globals__ is live and mutable, so
+      it answers with whatever the module means *now* rather than at
+      definition: rebinding int and then restoring it derives a signature from
+      the builtin though the annotation captured str, and rebinding it after
+      the def rejects a function whose annotation genuinely was the builtin.
+      Per-function metadata does not settle it either, and gets less stable
+      over time rather than more. Up to 3.13 without PEP 563, __annotations__
+      holds the definition-time object; under "from __future__ import
+      annotations" it holds strings, and inspect.get_annotations(eval_str=True)
+      evaluates them against those same live globals. On 3.14, PEP 649 defers
+      evaluation by default, so __annotations__ resolves on first *access*
+      against the module as it is by then — the two rebinding cases above
+      report the opposite of what they report on 3.13. There is therefore no
+      per-function binding that is stable across the supported versions. A
+      reserved spelling is deterministic, needs no runtime context, and matches
+      how the annotations are already read: from the ast, by name.
     parameters:
-      extracted:
-        type: ExtractedSource
       annotation:
         type: ast.expr | None
     returns:
-      type: tuple[SigType | None, str | None]
+      type: SigType | None
     """
     if not isinstance(annotation, ast.Name):
-        return None, _SUPPORTED
-    sig_type = _ANNOTATION_TYPES.get(annotation.id)
-    if sig_type is None:
-        return None, _SUPPORTED
-    shadow = _annotation_shadow(extracted, annotation.id)
-    if shadow is not None:
-        return None, (
-            f"{annotation.id!r} is bound to {shadow} here, so it does not"
-            " refer to the builtin"
-        )
-    return sig_type, None
+        return None
+    return _ANNOTATION_TYPES.get(annotation.id)
 
 
 def _argument_types(
@@ -270,14 +230,14 @@ def _argument_types(
                 )
             )
             continue
-        arg_type, reason = _resolve_annotation(extracted, parameter.annotation)
+        arg_type = _annotation_type(parameter.annotation)
         if arg_type is None:
             diagnostics.append(
                 diagnostic(
                     extracted,
                     parameter.annotation,
                     f"unsupported type annotation for parameter"
-                    f" {parameter.arg!r}: {reason}",
+                    f" {parameter.arg!r}: {_SUPPORTED}",
                 )
             )
             continue
@@ -305,13 +265,13 @@ def _return_type(
                 f"{node.name!r} has no return type annotation",
             )
         ]
-    return_type, reason = _resolve_annotation(extracted, node.returns)
+    return_type = _annotation_type(node.returns)
     if return_type is None:
         return None, [
             diagnostic(
                 extracted,
                 node.returns,
-                f"unsupported return type annotation: {reason}",
+                f"unsupported return type annotation: {_SUPPORTED}",
             )
         ]
     return return_type, []
@@ -371,10 +331,10 @@ def resolve_signature(
       definition: the argument shape and the number of parameters are checked
       against the function first, on both paths, because those are facts rather
       than choices. Without an explicit signature, the annotations are used;
-      see _annotation_shadow for the one rebinding of a builtin annotation name
-      that this cannot detect. The returned signature is None exactly when the
-      returned diagnostics are non-empty, which is the caller's signal that the
-      function cannot be compiled.
+      int, float and bool are reserved spellings there, so see _annotation_type
+      for why they are not resolved through the defining namespace. The
+      returned signature is None exactly when the returned diagnostics are non-
+      empty, which is the caller's signal that the function cannot be compiled.
     parameters:
       extracted:
         type: ExtractedSource

--- a/packages/arxjit/src/arxjit/reconcile.py
+++ b/packages/arxjit/src/arxjit/reconcile.py
@@ -162,18 +162,26 @@ def _annotation_shadow(
 ) -> str | None:
     """
     title: Return what shadows a builtin annotation name, or None.
-    summary: >-
+    summary: |-
       An annotation is matched by spelling, so ``int`` must still resolve to
       builtins.int for that match to mean anything; rebinding the name makes
       the annotation denote something else entirely. Only the defining module's
       namespace is consulted. A function's own locals cannot apply, because
-      annotations are evaluated in the enclosing scope when the def executes,
-      and an enclosing function's rebinding is not observable here: freevars
-      records only the names the body reads, and an annotation is not part of
-      the body. When the namespace is unavailable (only for a hand-built
-      ExtractedSource; extract_source always provides it for a real function)
-      shadowing cannot be observed and the name is taken to be the builtin,
-      matching how validation treats a shadowed range.
+      annotations are evaluated in the enclosing scope when the def executes.
+      When the namespace is unavailable (only for a hand-built ExtractedSource;
+      extract_source always provides it for a real function) shadowing cannot
+      be observed and the name is taken to be the builtin, matching how
+      validation treats a shadowed range.
+      Rebinding by an enclosing *function* is a documented limitation: such a
+      function derives a signature from the builtin its annotation is spelled
+      after, with no diagnostic, even though the annotation denotes the rebound
+      value. Nothing extraction carries can reveal it, because the binding is
+      not a module global and freevars records only the names the body reads,
+      which an annotation is not. Reading __annotations__ instead would not
+      settle it: under "from __future__ import annotations" they hold strings,
+      and inspect.get_annotations(eval_str=True) evaluates those against
+      __globals__, which cannot see an enclosing scope, so it answers with the
+      builtin on every supported CPython.
     parameters:
       extracted:
         type: ExtractedSource
@@ -362,10 +370,11 @@ def resolve_signature(
       type-mismatch error. It does not override the structure of the
       definition: the argument shape and the number of parameters are checked
       against the function first, on both paths, because those are facts rather
-      than choices. Without an explicit signature, the annotations are used.
-      The returned signature is None exactly when the returned diagnostics are
-      non-empty, which is the caller's signal that the function cannot be
-      compiled.
+      than choices. Without an explicit signature, the annotations are used;
+      see _annotation_shadow for the one rebinding of a builtin annotation name
+      that this cannot detect. The returned signature is None exactly when the
+      returned diagnostics are non-empty, which is the caller's signal that the
+      function cannot be compiled.
     parameters:
       extracted:
         type: ExtractedSource

--- a/packages/arxjit/src/arxjit/reconcile.py
+++ b/packages/arxjit/src/arxjit/reconcile.py
@@ -1,0 +1,262 @@
+"""
+title: Signature reconciliation for arxjit.
+summary: >-
+  Third stage of the arxjit pipeline: decide which Signature a validated
+  function will be compiled against. An explicit signature= passed to @jit is
+  the source of truth and wins outright; otherwise the signature is derived
+  from the function's Python annotations; a function with neither is reported
+  and stays interpreted. Annotations are read from the ast rather than from
+  __annotations__ so that a module using "from __future__ import annotations"
+  behaves identically, and so every diagnostic can point at the exact
+  annotation that caused it.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.locations import diagnostic
+from arxjit.source import ExtractedSource
+from arxjit.types import Signature, SigType, bool_, f64, i64
+
+# Only the Python builtins with an unambiguous scalar meaning are mapped.
+# Note that this can never produce i32/f32: Python has no annotation that
+# distinguishes widths, so the narrow types stay explicit-signature only.
+_ANNOTATION_TYPES: dict[str, SigType] = {
+    "bool": bool_,
+    "float": f64,
+    "int": i64,
+}
+
+_SUPPORTED = "only int, float and bool are supported"
+
+
+def _parameters(args: ast.arguments) -> list[ast.arg]:
+    """
+    title: Return the positional parameters of a function.
+    summary: >-
+      Positional-only parameters are included because validation permits them:
+      they are ordinary positional arguments to a compiled function. Anything
+      that is not positional is reported by _unsupported_shape rather than
+      being silently left out of the signature.
+    parameters:
+      args:
+        type: ast.arguments
+    returns:
+      type: list[ast.arg]
+    """
+    return [*args.posonlyargs, *args.args]
+
+
+def _unsupported_shape(
+    extracted: ExtractedSource,
+    args: ast.arguments,
+) -> list[Diagnostic]:
+    """
+    title: Reject an argument shape a positional signature cannot express.
+    summary: >-
+      A Signature is a fixed list of positional argument types, so a variadic
+      or keyword-only parameter has nowhere to go. Validation already rejects
+      these shapes, which makes this unreachable through @jit, but
+      resolve_signature is public: without the check it would drop the
+      parameters and return a signature that is quietly wrong (i64() for a
+      function taking *args) rather than saying it cannot derive one.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      args:
+        type: ast.arguments
+    returns:
+      type: list[Diagnostic]
+    """
+    offender = next(
+        (
+            node
+            for node in (args.vararg, args.kwarg, *args.kwonlyargs)
+            if node is not None
+        ),
+        None,
+    )
+    if offender is None:
+        return []
+    return [
+        diagnostic(
+            extracted,
+            offender,
+            "cannot derive a signature: only positional parameters are"
+            " supported, not variadic or keyword-only ones",
+        )
+    ]
+
+
+def _annotation_type(annotation: ast.expr | None) -> SigType | None:
+    """
+    title: Map an annotation expression to a supported scalar type.
+    summary: >-
+      Only a bare name is accepted, which is what int, float and bool parse to.
+      Anything else (a subscript such as list[int], an attribute such as
+      np.float64, a string, or an alias bound to a supported builtin) yields
+      None, so the caller reports it against the annotation's own location.
+    parameters:
+      annotation:
+        type: ast.expr | None
+    returns:
+      type: SigType | None
+    """
+    if not isinstance(annotation, ast.Name):
+        return None
+    return _ANNOTATION_TYPES.get(annotation.id)
+
+
+def _argument_types(
+    extracted: ExtractedSource,
+    parameters: list[ast.arg],
+) -> tuple[list[SigType], list[Diagnostic]]:
+    """
+    title: Resolve every parameter annotation to a scalar type.
+    summary: >-
+      Collects one diagnostic per unusable parameter rather than stopping at
+      the first, matching how validation reports the whole function at once. A
+      missing annotation is reported against the parameter and an unsupported
+      one against the annotation itself, so the caret lands on what to change.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      parameters:
+        type: list[ast.arg]
+    returns:
+      type: tuple[list[SigType], list[Diagnostic]]
+    """
+    arg_types: list[SigType] = []
+    diagnostics: list[Diagnostic] = []
+    for parameter in parameters:
+        if parameter.annotation is None:
+            diagnostics.append(
+                diagnostic(
+                    extracted,
+                    parameter,
+                    f"parameter {parameter.arg!r} has no type annotation",
+                )
+            )
+            continue
+        arg_type = _annotation_type(parameter.annotation)
+        if arg_type is None:
+            diagnostics.append(
+                diagnostic(
+                    extracted,
+                    parameter.annotation,
+                    f"unsupported type annotation for parameter"
+                    f" {parameter.arg!r}: {_SUPPORTED}",
+                )
+            )
+            continue
+        arg_types.append(arg_type)
+    return arg_types, diagnostics
+
+
+def _return_type(
+    extracted: ExtractedSource,
+) -> tuple[SigType | None, list[Diagnostic]]:
+    """
+    title: Resolve the return annotation to a scalar type.
+    parameters:
+      extracted:
+        type: ExtractedSource
+    returns:
+      type: tuple[SigType | None, list[Diagnostic]]
+    """
+    node = extracted.node
+    if node.returns is None:
+        return None, [
+            diagnostic(
+                extracted,
+                node,
+                f"{node.name!r} has no return type annotation",
+            )
+        ]
+    return_type = _annotation_type(node.returns)
+    if return_type is None:
+        return None, [
+            diagnostic(
+                extracted,
+                node.returns,
+                f"unsupported return type annotation: {_SUPPORTED}",
+            )
+        ]
+    return return_type, []
+
+
+def _from_annotations(
+    extracted: ExtractedSource,
+) -> tuple[Signature | None, list[Diagnostic]]:
+    """
+    title: Derive a Signature from a function's Python annotations.
+    summary: >-
+      An argument shape a positional signature cannot express is reported on
+      its own, because the annotation analysis below would be meaningless for
+      it. A function with no annotations at all is not an error: nothing was
+      requested, so it is reported at WARNING severity and stays interpreted.
+      Once any annotation is present the function is treated as asking to be
+      compiled, so every remaining gap is an ERROR.
+    parameters:
+      extracted:
+        type: ExtractedSource
+    returns:
+      type: tuple[Signature | None, list[Diagnostic]]
+    """
+    node = extracted.node
+    shape = _unsupported_shape(extracted, node.args)
+    if shape:
+        return None, shape
+
+    parameters = _parameters(node.args)
+    annotated = any(p.annotation is not None for p in parameters)
+    if not annotated and node.returns is None:
+        return None, [
+            diagnostic(
+                extracted,
+                node,
+                f"{node.name!r} stays interpreted: no signature= was given"
+                " and it has no type annotations",
+                DiagnosticSeverity.WARNING,
+            )
+        ]
+
+    arg_types, diagnostics = _argument_types(extracted, parameters)
+    return_type, return_diagnostics = _return_type(extracted)
+    diagnostics.extend(return_diagnostics)
+    if return_type is None or diagnostics:
+        return None, diagnostics
+    return Signature(return_type=return_type, arg_types=tuple(arg_types)), []
+
+
+def resolve_signature(
+    extracted: ExtractedSource,
+    explicit: Signature | None = None,
+) -> tuple[Signature | None, list[Diagnostic]]:
+    """
+    title: Decide the Signature a validated function compiles against.
+    summary: >-
+      An explicit signature wins outright and the annotations are not even
+      read, so a function may annotate freely (or not at all) without having to
+      agree with it; there is deliberately no mismatch error. Without one, the
+      annotations are used. The returned signature is None exactly when the
+      returned diagnostics are non-empty, which is the caller's signal that the
+      function cannot be compiled.
+    parameters:
+      extracted:
+        type: ExtractedSource
+        description: A function that has already passed validation.
+      explicit:
+        type: Signature | None
+        description: The signature= passed to @jit, when given.
+    returns:
+      type: tuple[Signature | None, list[Diagnostic]]
+    """
+    if explicit is not None:
+        return explicit, []
+    return _from_annotations(extracted)
+
+
+__all__ = ["resolve_signature"]

--- a/packages/arxjit/src/arxjit/validation.py
+++ b/packages/arxjit/src/arxjit/validation.py
@@ -20,8 +20,9 @@ import builtins
 
 from plum import dispatch
 
-from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.diagnostics import Diagnostic
 from arxjit.errors import UnsupportedSyntaxError
+from arxjit.locations import diagnostic as _diagnostic
 from arxjit.source import ExtractedSource
 
 FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
@@ -103,69 +104,6 @@ _UNSUPPORTED_MESSAGES: dict[type[ast.AST], str] = {
 # module still imports cleanly on 3.10.
 if (_try_star := getattr(ast, "TryStar", None)) is not None:
     _UNSUPPORTED_MESSAGES[_try_star] = "try/except* is not supported"
-
-
-def _char_column(line: str, byte_offset: int) -> int:
-    """
-    title: Convert a zero-based UTF-8 byte offset to a one-based column.
-    summary: >-
-      ast column offsets are zero-based UTF-8 byte offsets into their source
-      line, but Diagnostic.column is documented as a one-based Unicode
-      character column. Decoding the byte prefix back to text and measuring its
-      length performs the conversion exactly, including when multi-byte
-      characters appear before the target column.
-    parameters:
-      line:
-        type: str
-        description: The real source line the offset was reported against.
-      byte_offset:
-        type: int
-    returns:
-      type: int
-    """
-    prefix = line.encode("utf-8")[:byte_offset]
-    return len(prefix.decode("utf-8", errors="replace")) + 1
-
-
-def _diagnostic(
-    extracted: ExtractedSource,
-    node: ast.AST,
-    message: str,
-) -> Diagnostic:
-    """
-    title: Build an ERROR diagnostic located at an ast node.
-    summary: >-
-      Reads the node's lineno/col_offset when present and converts the column
-      to the one-based character contract via _char_column; falls back to no
-      location when the node carries none. node.lineno is a real file line
-      number (extract_source already shifted it), while extracted.source is
-      indexed from its own first line, so the node's line is looked up at
-      splitlines()[lineno - extracted.lineno] rather than lineno - 1.
-    parameters:
-      extracted:
-        type: ExtractedSource
-      node:
-        type: ast.AST
-      message:
-        type: str
-    returns:
-      type: Diagnostic
-    """
-    lineno = getattr(node, "lineno", None)
-    col_offset = getattr(node, "col_offset", None)
-    column = None
-    if lineno is not None and col_offset is not None:
-        lines = extracted.source.splitlines()
-        index = lineno - extracted.lineno
-        if 0 <= index < len(lines):
-            column = _char_column(lines[index], col_offset)
-    return Diagnostic(
-        severity=DiagnosticSeverity.ERROR,
-        message=message,
-        filename=extracted.filename,
-        line=lineno,
-        column=column,
-    )
 
 
 def _defined_in_class_body(qualname: str) -> bool:

--- a/packages/arxjit/tests/test_reconcile.py
+++ b/packages/arxjit/tests/test_reconcile.py
@@ -1,0 +1,347 @@
+"""
+title: Tests for signature reconciliation.
+"""
+
+import ast
+
+from typing import Any, Callable
+
+import pytest
+
+from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
+from arxjit.reconcile import resolve_signature
+from arxjit.source import ExtractedSource, extract_source
+from arxjit.types import Signature, bool_, f64, i64
+
+PyFunc = Callable[..., Any]
+
+
+def _resolve(
+    fn: PyFunc,
+    explicit: Signature | None = None,
+) -> tuple[Signature | None, list[Diagnostic]]:
+    """
+    title: Extract a function and resolve its signature (test helper).
+    parameters:
+      fn:
+        type: PyFunc
+      explicit:
+        type: Signature | None
+    returns:
+      type: tuple[Signature | None, list[Diagnostic]]
+    """
+    return resolve_signature(extract_source(fn), explicit)
+
+
+def test_annotations_map_to_scalar_types() -> None:
+    """
+    title: int, float and bool annotations map to i64, f64 and bool_.
+    """
+
+    def sample(a: int, b: float, c: bool) -> float:
+        """
+        title: Combine three scalars.
+        parameters:
+          a:
+            type: int
+          b:
+            type: float
+          c:
+            type: bool
+        returns:
+          type: float
+        """
+        if c:
+            return a + b
+        return b
+
+    signature, diagnostics = _resolve(sample)
+    assert diagnostics == []
+    assert signature == f64(i64, f64, bool_)
+
+
+def test_explicit_signature_short_circuits() -> None:
+    """
+    title: An explicit signature is returned as-is with no diagnostics.
+    summary: >-
+      The annotations are not read at all, so even a function that could not
+      produce a signature on its own resolves cleanly.
+    """
+
+    def sample(a, b):  # type: ignore[no-untyped-def]
+        """
+        title: Add two values of unknown type.
+        parameters:
+          a:
+          b:
+        returns:
+          type: object
+        """
+        return a + b
+
+    explicit = i64(i64, i64)
+    signature, diagnostics = _resolve(sample, explicit)
+    assert signature is explicit
+    assert diagnostics == []
+
+
+def test_positional_only_parameters_are_included() -> None:
+    """
+    title: Positional-only parameters appear in the derived signature.
+    summary: >-
+      Validation permits them, so reconciliation must not silently drop them
+      from the argument list.
+    """
+
+    def sample(a: int, /, b: float) -> float:
+        """
+        title: Add a positional-only and an ordinary parameter.
+        parameters:
+          a:
+            type: int
+          b:
+            type: float
+        returns:
+          type: float
+        """
+        return a + b
+
+    signature, diagnostics = _resolve(sample)
+    assert diagnostics == []
+    assert signature == f64(i64, f64)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "def sample(*args: int) -> int:\n    return 1\n",
+        "def sample(**kwargs: int) -> int:\n    return 1\n",
+        "def sample(*, a: int) -> int:\n    return a\n",
+        "def sample(a: int, *rest: int) -> int:\n    return a\n",
+    ],
+    ids=["vararg", "kwarg", "kwonly", "positional-and-vararg"],
+)
+def test_non_positional_shape_cannot_derive_a_signature(source: str) -> None:
+    """
+    title: An argument shape a positional signature cannot express is refused.
+    summary: >-
+      Validation rejects these shapes first, so this is unreachable through
+      @jit, but resolve_signature is public: without the check it would leave
+      the parameters out and return a signature that is quietly wrong, such as
+      i64() for a function taking *args.
+    parameters:
+      source:
+        type: str
+    """
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    extracted = ExtractedSource(
+        filename="<test>", source=source, lineno=1, node=node
+    )
+    signature, (diagnostic,) = resolve_signature(extracted)
+    assert signature is None
+    assert "only positional parameters are supported" in diagnostic.message
+    assert diagnostic.severity is DiagnosticSeverity.ERROR
+
+
+def test_zero_parameter_function_resolves() -> None:
+    """
+    title: A function with no parameters resolves from its return annotation.
+    """
+
+    def sample() -> int:
+        """
+        title: Return a constant.
+        returns:
+          type: int
+        """
+        return 1
+
+    signature, diagnostics = _resolve(sample)
+    assert diagnostics == []
+    assert signature == i64()
+
+
+def test_no_annotations_warns_once() -> None:
+    """
+    title: A wholly unannotated function yields a single WARNING.
+    """
+
+    def sample(a, b):  # type: ignore[no-untyped-def]
+        """
+        title: Add two values of unknown type.
+        parameters:
+          a:
+          b:
+        returns:
+          type: object
+        """
+        return a + b
+
+    signature, (diagnostic,) = _resolve(sample)
+    assert signature is None
+    assert diagnostic.severity is DiagnosticSeverity.WARNING
+    assert "stays interpreted" in diagnostic.message
+
+
+def test_missing_return_annotation_is_an_error() -> None:
+    """
+    title: Annotated parameters with no return annotation is an error.
+    """
+
+    def sample(a: int):  # type: ignore[no-untyped-def]
+        """
+        title: Return the argument unchanged.
+        parameters:
+          a:
+            type: int
+        returns:
+          type: int
+        """
+        return a
+
+    signature, (diagnostic,) = _resolve(sample)
+    assert signature is None
+    assert diagnostic.severity is DiagnosticSeverity.ERROR
+    assert "has no return type annotation" in diagnostic.message
+
+
+def test_unsupported_return_annotation_is_an_error() -> None:
+    """
+    title: A return annotation outside the supported scalars is rejected.
+    """
+
+    def sample(a: int) -> str:
+        """
+        title: Render the argument.
+        parameters:
+          a:
+            type: int
+        returns:
+          type: str
+        """
+        return "x"
+
+    signature, (diagnostic,) = _resolve(sample)
+    assert signature is None
+    assert "unsupported return type annotation" in diagnostic.message
+
+
+def test_subscripted_annotation_is_rejected() -> None:
+    """
+    title: A subscripted annotation such as list[int] is not a scalar.
+    """
+
+    def sample(values: list[int]) -> int:
+        """
+        title: Return a constant, ignoring the argument.
+        parameters:
+          values:
+            type: list[int]
+        returns:
+          type: int
+        """
+        return 1
+
+    signature, (diagnostic,) = _resolve(sample)
+    assert signature is None
+    assert "unsupported type annotation for parameter 'values'" in (
+        diagnostic.message
+    )
+
+
+def test_dotted_annotation_is_rejected() -> None:
+    """
+    title: A dotted annotation such as decimal.Decimal is not a scalar.
+    """
+
+    def sample(value: ast.AST) -> int:
+        """
+        title: Return a constant, ignoring the argument.
+        parameters:
+          value:
+            type: ast.AST
+        returns:
+          type: int
+        """
+        return 1
+
+    signature, (diagnostic,) = _resolve(sample)
+    assert signature is None
+    assert "unsupported type annotation for parameter 'value'" in (
+        diagnostic.message
+    )
+
+
+def test_every_bad_parameter_is_reported() -> None:
+    """
+    title: Reconciliation collects all bad parameters, not just the first.
+    """
+
+    def sample(a: str, b, c: int) -> int:  # type: ignore[no-untyped-def]
+        """
+        title: Combine three values.
+        parameters:
+          a:
+            type: str
+          b:
+          c:
+            type: int
+        returns:
+          type: int
+        """
+        return c
+
+    signature, diagnostics = _resolve(sample)
+    assert signature is None
+    messages = [d.message for d in diagnostics]
+    assert len(messages) == 2
+    assert "parameter 'a'" in messages[0]
+    assert "parameter 'b'" in messages[1]
+
+
+def test_diagnostic_points_at_the_annotation() -> None:
+    """
+    title: An unsupported annotation is located at the annotation itself.
+    """
+
+    def sample(value: str) -> int:
+        """
+        title: Return a constant, ignoring the argument.
+        parameters:
+          value:
+            type: str
+        returns:
+          type: int
+        """
+        return 1
+
+    extracted = extract_source(sample)
+    _, (diagnostic,) = resolve_signature(extracted)
+    lines = extracted.source.splitlines()
+    real_line = lines[diagnostic.line - extracted.lineno]
+    assert diagnostic.column is not None
+    assert real_line[diagnostic.column - 1 :].startswith("str")
+
+
+def test_string_annotations_are_read_from_the_ast() -> None:
+    """
+    title: A quoted annotation resolves like an ordinary one.
+    summary: >-
+      "from __future__ import annotations" turns every annotation into a string
+      at runtime; reading them from the ast instead of __annotations__ makes
+      that irrelevant. A quoted annotation is the same situation written out by
+      hand, and parses to a Constant rather than a Name, so it is reported
+      rather than silently accepted.
+    """
+    source = 'def sample(x: "int") -> int:\n    return x\n'
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    extracted = ExtractedSource(
+        filename="<test>", source=source, lineno=1, node=node
+    )
+    signature, (diagnostic,) = resolve_signature(extracted)
+    assert signature is None
+    assert "unsupported type annotation for parameter 'x'" in (
+        diagnostic.message
+    )

--- a/packages/arxjit/tests/test_reconcile.py
+++ b/packages/arxjit/tests/test_reconcile.py
@@ -507,6 +507,51 @@ def test_absent_namespace_assumes_the_builtin() -> None:
     assert signature == i64(i64)
 
 
+def test_enclosing_scope_shadowing_is_not_detected() -> None:
+    """
+    title: An annotation rebound by an enclosing function is not detected.
+    summary: >-
+      Documented limitation rather than an oversight, pinned in the same spirit
+      as the method forms validation cannot detect from source metadata alone.
+      The annotation here denotes str, as __annotations__ confirms, but the
+      rebinding is neither a module global nor a name the body reads, so
+      nothing extraction carries reveals it and a signature is derived from the
+      builtin the annotation is spelled after. Pinned so the contract is
+      explicit and a future fix has a test to flip.
+    """
+
+    def outer() -> PyFunc:
+        """
+        title: Return a function annotated against a rebound builtin.
+        returns:
+          type: PyFunc
+        """
+        int = str
+
+        def kernel(x: int) -> int:
+            """
+            title: Return the argument unchanged.
+            parameters:
+              x:
+                type: int
+            returns:
+              type: int
+            """
+            return x
+
+        return kernel
+
+    kernel = outer()
+    # Establishes that the annotation really does denote str, which is what
+    # makes this a gap rather than a preference. Reads as the evaluated type
+    # only because this module does not stringify its annotations; under
+    # "from __future__ import annotations" it would hold the string "int".
+    assert kernel.__annotations__ == {"x": str, "return": str}
+    signature, diagnostics = _resolve(kernel)
+    assert diagnostics == []
+    assert signature == i64(i64)
+
+
 def test_diagnostic_points_at_the_annotation() -> None:
     """
     title: An unsupported annotation is located at the annotation itself.

--- a/packages/arxjit/tests/test_reconcile.py
+++ b/packages/arxjit/tests/test_reconcile.py
@@ -73,7 +73,9 @@ def test_explicit_signature_short_circuits() -> None:
         title: Add two values of unknown type.
         parameters:
           a:
+            description: The left operand, deliberately unannotated.
           b:
+            description: The right operand, deliberately unannotated.
         returns:
           type: object
         """
@@ -172,7 +174,9 @@ def test_no_annotations_warns_once() -> None:
         title: Add two values of unknown type.
         parameters:
           a:
+            description: The left operand, deliberately unannotated.
           b:
+            description: The right operand, deliberately unannotated.
         returns:
           type: object
         """
@@ -285,6 +289,7 @@ def test_every_bad_parameter_is_reported() -> None:
           a:
             type: str
           b:
+            description: The middle operand, deliberately unannotated.
           c:
             type: int
         returns:

--- a/packages/arxjit/tests/test_reconcile.py
+++ b/packages/arxjit/tests/test_reconcile.py
@@ -3,13 +3,15 @@ title: Tests for signature reconciliation.
 """
 
 import ast
+import importlib.util
+import pathlib
 
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 import pytest
 
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
-from arxjit.reconcile import resolve_signature
+from arxjit.reconcile import _ANNOTATION_TYPES, resolve_signature
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.types import Signature, bool_, f64, i64
 
@@ -427,97 +429,146 @@ def test_every_bad_parameter_is_reported() -> None:
     assert "parameter 'b'" in messages[1]
 
 
-def _with_namespace(
-    source: str,
-    globalns: dict[str, Any] | None,
-) -> ExtractedSource:
+_REBOUND_THEN_RESTORED = """import builtins
+
+int = str
+
+
+def kernel(x: int) -> int:
+    return x
+
+
+int = builtins.int
+"""
+
+_REBOUND_AFTER_DEF = """def kernel(x: int) -> int:
+    return x
+
+
+int = str
+"""
+
+
+def _module_function(tmp_path: pathlib.Path, name: str, source: str) -> PyFunc:
     """
-    title: Build an ExtractedSource with a chosen namespace (test helper).
+    title: Import a written-out module and return its kernel (test helper).
+    summary: >-
+      A real module is needed rather than a hand-built ExtractedSource: the
+      point of these cases is what the module's live globals do after the
+      function is defined, which only a real import reproduces.
     parameters:
+      tmp_path:
+        type: pathlib.Path
+      name:
+        type: str
       source:
         type: str
-      globalns:
-        type: dict[str, Any] | None
     returns:
-      type: ExtractedSource
+      type: PyFunc
     """
-    node = ast.parse(source).body[0]
-    assert isinstance(node, ast.FunctionDef)
-    return ExtractedSource(
-        filename="<test>",
-        source=source,
-        lineno=1,
-        node=node,
-        globalns=globalns,
-    )
+    path = tmp_path / f"{name}.py"
+    path.write_text(source, encoding="utf-8")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return cast(PyFunc, module.kernel)
 
 
 @pytest.mark.parametrize("name", ["int", "float", "bool"])
-def test_shadowed_builtin_annotation_is_rejected(name: str) -> None:
+def test_reserved_spelling_wins_over_the_defining_namespace(
+    name: str,
+) -> None:
     """
-    title: An annotation naming a rebound builtin is not that builtin.
+    title: A rebound builtin name still denotes the reserved scalar type.
     summary: >-
-      Annotations are matched by spelling, so the name has to still resolve to
-      the builtin for the match to mean anything. Rebinding it at module level
-      makes the annotation denote something else entirely, which no amount of
-      ast inspection can reveal; the namespace extraction carries is what
-      settles it.
+      int, float and bool are reserved annotation spellings, so a module that
+      rebinds one does not change what the annotation means to the compiler.
+      The namespace is deliberately not consulted; see _annotation_type for why
+      resolving through it cannot be made sound.
     parameters:
       name:
         type: str
     """
     source = f"def sample(value: {name}) -> {name}:\n    return value\n"
-    extracted = _with_namespace(source, {name: str})
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    extracted = ExtractedSource(
+        filename="<test>",
+        source=source,
+        lineno=1,
+        node=node,
+        globalns={name: str},
+    )
     signature, diagnostics = resolve_signature(extracted)
-    assert signature is None
-    assert len(diagnostics) == 2
-    for diagnostic in diagnostics:
-        assert f"{name!r} is bound to a module-level name" in (
-            diagnostic.message
-        )
-        assert "does not refer to the builtin" in diagnostic.message
+    assert diagnostics == []
+    assert (
+        str(signature)
+        == f"{_ANNOTATION_TYPES[name]}({_ANNOTATION_TYPES[name]})"
+    )
 
 
-def test_unshadowed_module_namespace_is_accepted() -> None:
+def test_rebinding_restored_after_definition_still_resolves(
+    tmp_path: pathlib.Path,
+) -> None:
     """
-    title: A namespace that leaves the builtins alone resolves normally.
+    title: A name rebound at definition and restored after resolves the same.
     summary: >-
-      The control for the shadowing test: carrying a namespace must not by
-      itself make an annotation suspect.
+      One of the two directions live globals get wrong: __annotations__ records
+      str, because that was the binding when the def ran, but the module now
+      says int is the builtin. A namespace-based check would answer from the
+      restored binding and derive a signature the annotation never meant. The
+      reserved spelling answers the same either way.
+    parameters:
+      tmp_path:
+        type: pathlib.Path
     """
-    source = "def sample(value: int) -> int:\n    return value\n"
-    extracted = _with_namespace(source, {"unrelated": 1})
-    signature, diagnostics = resolve_signature(extracted)
+    kernel = _module_function(
+        tmp_path, "rebound_restored", _REBOUND_THEN_RESTORED
+    )
+    # What __annotations__ reports is itself version-dependent, which is the
+    # point: up to 3.13 it holds the object captured when the def ran, while
+    # 3.14 defers evaluation (PEP 649) and resolves on first access against
+    # the module as it is by then. The resolver must not vary with either.
+    assert kernel.__annotations__["x"] in (int, str)
+    signature, diagnostics = _resolve(kernel)
     assert diagnostics == []
     assert signature == i64(i64)
 
 
-def test_absent_namespace_assumes_the_builtin() -> None:
+def test_rebinding_after_definition_still_resolves(
+    tmp_path: pathlib.Path,
+) -> None:
     """
-    title: Without a namespace, shadowing is unobservable and assumed absent.
+    title: A name rebound only after the def resolves the same.
     summary: >-
-      Documented fail-open, matching how validation treats a shadowed range:
-      only a hand-built ExtractedSource lacks a namespace, since extract_source
-      always provides one for a real function.
+      The other direction: the annotation genuinely denoted the builtin when
+      the function was defined, and a namespace-based check would reject it
+      because the module was rebound afterwards. Nothing about the function
+      changed, so nothing about its signature does.
+    parameters:
+      tmp_path:
+        type: pathlib.Path
     """
-    source = "def sample(value: int) -> int:\n    return value\n"
-    extracted = _with_namespace(source, None)
-    signature, diagnostics = resolve_signature(extracted)
+    kernel = _module_function(tmp_path, "rebound_after", _REBOUND_AFTER_DEF)
+    # What __annotations__ reports is itself version-dependent, which is the
+    # point: up to 3.13 it holds the object captured when the def ran, while
+    # 3.14 defers evaluation (PEP 649) and resolves on first access against
+    # the module as it is by then. The resolver must not vary with either.
+    assert kernel.__annotations__["x"] in (int, str)
+    signature, diagnostics = _resolve(kernel)
     assert diagnostics == []
     assert signature == i64(i64)
 
 
-def test_enclosing_scope_shadowing_is_not_detected() -> None:
+def test_enclosing_scope_rebinding_still_resolves() -> None:
     """
-    title: An annotation rebound by an enclosing function is not detected.
+    title: A name rebound by an enclosing function resolves the same.
     summary: >-
-      Documented limitation rather than an oversight, pinned in the same spirit
-      as the method forms validation cannot detect from source metadata alone.
-      The annotation here denotes str, as __annotations__ confirms, but the
-      rebinding is neither a module global nor a name the body reads, so
-      nothing extraction carries reveals it and a signature is derived from the
-      builtin the annotation is spelled after. Pinned so the contract is
-      explicit and a future fix has a test to flip.
+      The annotation here denotes str, as __annotations__ confirms, and under
+      the reserved-spelling contract that does not matter: the spelling is what
+      selects the type. This was previously pinned as a limitation of the
+      namespace check; it is now an instance of the rule.
     """
 
     def outer() -> PyFunc:
@@ -542,10 +593,6 @@ def test_enclosing_scope_shadowing_is_not_detected() -> None:
         return kernel
 
     kernel = outer()
-    # Establishes that the annotation really does denote str, which is what
-    # makes this a gap rather than a preference. Reads as the evaluated type
-    # only because this module does not stringify its annotations; under
-    # "from __future__ import annotations" it would hold the string "int".
     assert kernel.__annotations__ == {"x": str, "return": str}
     signature, diagnostics = _resolve(kernel)
     assert diagnostics == []

--- a/packages/arxjit/tests/test_reconcile.py
+++ b/packages/arxjit/tests/test_reconcile.py
@@ -87,6 +87,128 @@ def test_explicit_signature_short_circuits() -> None:
     assert diagnostics == []
 
 
+def test_explicit_signature_arity_must_match_the_function() -> None:
+    """
+    title: An explicit signature cannot declare a different argument count.
+    summary: >-
+      The explicit signature decides types, which is the caller's choice, but
+      how many parameters the function has is a fact of the definition. A
+      signature that disagrees would compile to a calling convention Python
+      cannot satisfy.
+    """
+
+    def sample(a, b):  # type: ignore[no-untyped-def]
+        """
+        title: Add two values of unknown type.
+        parameters:
+          a:
+            description: The left operand, deliberately unannotated.
+          b:
+            description: The right operand, deliberately unannotated.
+        returns:
+          type: object
+        """
+        return a + b
+
+    signature, (diagnostic,) = _resolve(sample, i64(i64))
+    assert signature is None
+    assert diagnostic.message == (
+        "signature declares 1 argument but 'sample' takes 2"
+    )
+    assert diagnostic.severity is DiagnosticSeverity.ERROR
+
+
+def test_arity_message_pluralizes_the_declared_count() -> None:
+    """
+    title: The mismatch message agrees in number with the declared count.
+    summary: >-
+      The singular case is covered above; this pins the other side, which line
+      coverage cannot distinguish because both sit on one conditional
+      expression.
+    """
+
+    def sample(x: int) -> int:
+        """
+        title: Return the argument unchanged.
+        parameters:
+          x:
+            type: int
+        returns:
+          type: int
+        """
+        return x
+
+    signature, (diagnostic,) = _resolve(sample, i64(i64, i64))
+    assert signature is None
+    assert diagnostic.message == (
+        "signature declares 2 arguments but 'sample' takes 1"
+    )
+
+
+def test_explicit_signature_with_matching_arity_is_accepted() -> None:
+    """
+    title: A correctly sized explicit signature still short-circuits.
+    summary: >-
+      The arity check must not disturb the rule that an explicit signature
+      wins: the annotations here say float and are still not consulted.
+    """
+
+    def sample(x: float) -> float:
+        """
+        title: Return the argument unchanged.
+        parameters:
+          x:
+            type: float
+        returns:
+          type: float
+        """
+        return x
+
+    explicit = i64(i64)
+    signature, diagnostics = _resolve(sample, explicit)
+    assert signature is explicit
+    assert diagnostics == []
+
+
+def test_explicit_signature_does_not_bypass_the_shape_check() -> None:
+    """
+    title: A non-positional shape is rejected even with an explicit signature.
+    summary: >-
+      The structural checks run before the explicit signature is accepted, so
+      passing one cannot skip them. Only the shape is reported: counting the
+      positional parameters of a *args function would give a number that means
+      nothing to the caller.
+    """
+    source = "def sample(*args: int) -> int:\n    return 1\n"
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    extracted = ExtractedSource(
+        filename="<test>", source=source, lineno=1, node=node
+    )
+    signature, (diagnostic,) = resolve_signature(extracted, i64(i64))
+    assert signature is None
+    assert "only positional parameters are supported" in diagnostic.message
+
+
+def test_zero_argument_explicit_signature_matches_a_bare_function() -> None:
+    """
+    title: An empty explicit signature fits a function with no parameters.
+    """
+
+    def sample() -> int:
+        """
+        title: Return a constant.
+        returns:
+          type: int
+        """
+        return 1
+
+    explicit = i64()
+    signature, diagnostics = _resolve(sample, explicit)
+    assert signature is explicit
+    assert diagnostics == []
+
+
 def test_positional_only_parameters_are_included() -> None:
     """
     title: Positional-only parameters appear in the derived signature.
@@ -303,6 +425,86 @@ def test_every_bad_parameter_is_reported() -> None:
     assert len(messages) == 2
     assert "parameter 'a'" in messages[0]
     assert "parameter 'b'" in messages[1]
+
+
+def _with_namespace(
+    source: str,
+    globalns: dict[str, Any] | None,
+) -> ExtractedSource:
+    """
+    title: Build an ExtractedSource with a chosen namespace (test helper).
+    parameters:
+      source:
+        type: str
+      globalns:
+        type: dict[str, Any] | None
+    returns:
+      type: ExtractedSource
+    """
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    return ExtractedSource(
+        filename="<test>",
+        source=source,
+        lineno=1,
+        node=node,
+        globalns=globalns,
+    )
+
+
+@pytest.mark.parametrize("name", ["int", "float", "bool"])
+def test_shadowed_builtin_annotation_is_rejected(name: str) -> None:
+    """
+    title: An annotation naming a rebound builtin is not that builtin.
+    summary: >-
+      Annotations are matched by spelling, so the name has to still resolve to
+      the builtin for the match to mean anything. Rebinding it at module level
+      makes the annotation denote something else entirely, which no amount of
+      ast inspection can reveal; the namespace extraction carries is what
+      settles it.
+    parameters:
+      name:
+        type: str
+    """
+    source = f"def sample(value: {name}) -> {name}:\n    return value\n"
+    extracted = _with_namespace(source, {name: str})
+    signature, diagnostics = resolve_signature(extracted)
+    assert signature is None
+    assert len(diagnostics) == 2
+    for diagnostic in diagnostics:
+        assert f"{name!r} is bound to a module-level name" in (
+            diagnostic.message
+        )
+        assert "does not refer to the builtin" in diagnostic.message
+
+
+def test_unshadowed_module_namespace_is_accepted() -> None:
+    """
+    title: A namespace that leaves the builtins alone resolves normally.
+    summary: >-
+      The control for the shadowing test: carrying a namespace must not by
+      itself make an annotation suspect.
+    """
+    source = "def sample(value: int) -> int:\n    return value\n"
+    extracted = _with_namespace(source, {"unrelated": 1})
+    signature, diagnostics = resolve_signature(extracted)
+    assert diagnostics == []
+    assert signature == i64(i64)
+
+
+def test_absent_namespace_assumes_the_builtin() -> None:
+    """
+    title: Without a namespace, shadowing is unobservable and assumed absent.
+    summary: >-
+      Documented fail-open, matching how validation treats a shadowed range:
+      only a hand-built ExtractedSource lacks a namespace, since extract_source
+      always provides one for a real function.
+    """
+    source = "def sample(value: int) -> int:\n    return value\n"
+    extracted = _with_namespace(source, None)
+    signature, diagnostics = resolve_signature(extracted)
+    assert diagnostics == []
+    assert signature == i64(i64)
 
 
 def test_diagnostic_points_at_the_annotation() -> None:

--- a/packages/arxjit/tests/test_validation.py
+++ b/packages/arxjit/tests/test_validation.py
@@ -11,11 +11,11 @@ import pytest
 
 from arxjit.diagnostics import DiagnosticSeverity
 from arxjit.errors import UnsupportedSyntaxError
+from arxjit.locations import char_column
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.validation import (
     _UNSUPPORTED_MESSAGES,
     _bound_names,
-    _char_column,
     _SubsetValidator,
     validate,
 )
@@ -625,7 +625,7 @@ def test_nested_function_diagnostics_point_at_the_real_file() -> None:
 
 def test_char_column_converts_multibyte_prefixes() -> None:
     """
-    title: _char_column converts a UTF-8 byte offset to a character column.
+    title: char_column converts a UTF-8 byte offset to a character column.
     summary: >-
       A non-ASCII character earlier on the line makes the byte offset diverge
       from the character index; this directly pins the conversion independent
@@ -637,7 +637,7 @@ def test_char_column_converts_multibyte_prefixes() -> None:
     # makes it exceed the character index by exactly one.
     real_byte_offset = len(line[:char_index].encode("utf-8"))
     assert real_byte_offset == char_index + 1
-    assert _char_column(line, real_byte_offset) == char_index + 1
+    assert char_column(line, real_byte_offset) == char_index + 1
 
 
 def test_free_variable_read_is_rejected() -> None:


### PR DESCRIPTION
Follows #102. Closes the remaining open question in wiki Issue 2: *"decide how Python annotations interact with explicit signatures."*

## The rules

New `arxjit.reconcile` decides which `Signature` a validated function will be compiled against:

| given | result |
|---|---|
| explicit `signature=` | wins outright; annotations are **not read at all** |
| annotations only | signature derived from them |
| neither | reported at WARNING severity, function stays interpreted |
| some annotations, others missing or unsupported | every remaining gap is an ERROR |

Because an explicit signature short-circuits, a function may annotate freely without having to agree with it — there is deliberately no mismatch error, per the decision in the thread. The last row is the judgement call worth flagging: once a function annotates *anything*, it is read as asking to be compiled, so a gap elsewhere is an error rather than a silent fallback.

## Annotations are read from the ast, not `__annotations__`

A module using `from __future__ import annotations` turns every annotation into a string at runtime, which would otherwise have to be evaluated back with `eval_str`. Reading the ast makes that irrelevant, and lets each diagnostic point at the exact annotation that caused it rather than at the function.

Only a bare `int`, `float` or `bool` is accepted; a subscripted (`list[int]`), dotted (`np.float64`) or quoted (`"int"`) annotation is reported against its own location. One consequence worth naming: **this can never produce `i32` or `f32`**, since Python has no annotation that distinguishes widths, so the narrow types stay explicit-signature only. That partly answers the "should we trim i32/f32?" question from #91 — they remain reachable, just not from annotations.

Positional-only parameters are included in the derived signature. Validation permits them and they are ordinary positional arguments to a compiled function, so leaving them out would silently drop an argument.

## Fail-closed on argument shapes

`Signature` is a fixed list of positional argument types, so a variadic or keyword-only parameter has nowhere to go. Validation rejects those shapes first, which makes this unreachable through `@jit` — but `resolve_signature` is exported, and without a check it would leave the parameters out and hand back a signature that is quietly wrong (`i64()` for a function taking `*args`). It now reports that it cannot derive one instead. Four regression tests cover `*args`, `**kwargs`, keyword-only, and the mixed positional-plus-variadic case.

## Location helpers moved

`_char_column` and `_diagnostic` move out of `validation.py` into a new `arxjit.locations`, now that a second stage builds diagnostics from ast nodes. Single-sourcing them keeps the two stages from drifting on the column contract (one-based Unicode characters, converted from ast's zero-based UTF-8 byte offsets at the boundary). No behaviour change — a move, plus a `severity` parameter so reconciliation can emit WARNING.

## Note on scope

`resolve_signature` is exported and fully tested but **not yet consulted by `@jit`** — `core.py` is untouched here. Wiring it into the decorator, along with the `strict` flag and the warn-and-fall-back behaviour, is the next PR. Splitting it this way keeps the resolution rules reviewable on their own, separately from the decorator behaviour change.

## Verification

169 tests, arxjit coverage 100%. All gates green locally: pytest+cov, ruff format/check, mypy strict (`cd packages/arxjit && mypy src`), bandit `-iii -lll`, vulture 80, mccabe 10, `douki sync` idempotent. Verified on CPython 3.10.19, 3.11.11 and 3.14.6.