### PR TITLE
feat(arxjit): lower a validated function's shell to an astx module

### DIFF
--- a/packages/arxjit/pyproject.toml
+++ b/packages/arxjit/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "astx == 1.24.1",  # semantic-release
   "pyirx == 1.24.1",  # semantic-release
   "plum-dispatch >= 2",
+  "atpublic >= 4.0",
 ]
 
 [build-system]

--- a/packages/arxjit/src/arxjit/__init__.py
+++ b/packages/arxjit/src/arxjit/__init__.py
@@ -8,9 +8,11 @@ from arxjit.core import JitFunction, jit
 from arxjit.diagnostics import Diagnostic, DiagnosticSeverity
 from arxjit.errors import (
     ArxJitError,
+    LoweringError,
     SourceExtractionError,
     UnsupportedSyntaxError,
 )
+from arxjit.lowering import lower
 from arxjit.reconcile import resolve_signature
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.types import (
@@ -49,6 +51,7 @@ __all__ = [
     "DiagnosticSeverity",
     "ExtractedSource",
     "JitFunction",
+    "LoweringError",
     "SigType",
     "Signature",
     "SourceExtractionError",
@@ -62,6 +65,7 @@ __all__ = [
     "i32",
     "i64",
     "jit",
+    "lower",
     "resolve_signature",
     "validate",
 ]

--- a/packages/arxjit/src/arxjit/errors.py
+++ b/packages/arxjit/src/arxjit/errors.py
@@ -73,8 +73,24 @@ class UnsupportedSyntaxError(ArxJitError):
     """
 
 
+class LoweringError(ArxJitError):
+    """
+    title: Raised when a validated function cannot be lowered to astx.
+    summary: >-
+      Lowering runs on a function validation has already accepted, so this
+      reports a disagreement between the two stages rather than a mistake by
+      the user: a construct the subset admits that the lowerer has no astx
+      mapping for. It stays a distinct error because the fix is a change to
+      arxjit, not to the decorated function.
+    attributes:
+      diagnostics:
+        type: list[Diagnostic]
+    """
+
+
 __all__ = [
     "ArxJitError",
+    "LoweringError",
     "SourceExtractionError",
     "UnsupportedSyntaxError",
 ]

--- a/packages/arxjit/src/arxjit/lowering.py
+++ b/packages/arxjit/src/arxjit/lowering.py
@@ -1,0 +1,379 @@
+# mypy: disable-error-code=no-redef
+"""
+title: Python AST to ASTx lowering for arxjit.
+summary: >-
+  Fourth stage of the arxjit pipeline: turn the ast node of a validated
+  function, plus the Signature reconciliation settled on, into the astx module
+  IRx compiles. Dispatch is by node type via plum, matching the visitor
+  convention used across the Arx packages. This first version lowers the
+  function shell — the prototype, its typed arguments, and a body of literal
+  returns; variables, arithmetic, and control flow follow in later stages, and
+  until then any other construct fails closed with LoweringError. The decorator
+  does not call this stage yet, so nothing here changes what @jit does; that
+  wiring lands once the lowerer covers the whole validated subset.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import astx
+
+
+# Neither name is re-exported at the astx top level, so both are imported from
+# where they are defined: NO_SOURCE_LOCATION is astx's own default for every
+# loc parameter, and AnyType is what FunctionPrototype declares its return type
+# and Argument its type_ to be.
+from astx.base import NO_SOURCE_LOCATION
+from astx.types.base import AnyType
+from plum import dispatch
+
+from arxjit.errors import LoweringError
+from arxjit.locations import diagnostic
+from arxjit.source import ExtractedSource
+from arxjit.types import Signature, SigType
+
+# Bound by SigType.astx_name, which keeps arxjit.types free of any astx
+# import: the type API names its astx target, and this stage is where that
+# name becomes a class. Every SigType arxjit exports must appear here, which
+# test_every_sig_type_has_an_astx_class pins.
+_ASTX_TYPES: dict[str, type[AnyType]] = {
+    "Boolean": astx.Boolean,
+    "Float32": astx.Float32,
+    "Float64": astx.Float64,
+    "Int32": astx.Int32,
+    "Int64": astx.Int64,
+}
+
+# Ordered, and checked in order, because bool is a subclass of int in Python:
+# a True literal matches int too, and would lower to an integer without this.
+# Widths are the Python defaults rather than the signature's type; see the
+# ast.Constant overload for why the declared type deliberately does not drive
+# this.
+_LITERAL_TYPES: tuple[tuple[type, type[astx.Literal]], ...] = (
+    (bool, astx.LiteralBoolean),
+    (int, astx.LiteralInt64),
+    (float, astx.LiteralFloat64),
+)
+
+
+def _location(
+    extracted: ExtractedSource, node: ast.AST
+) -> astx.SourceLocation:
+    """
+    title: Convert an ast node's position into an astx source location.
+    summary: >-
+      Reuses the diagnostic builder so astx nodes carry exactly the positions
+      arxjit reports in its own diagnostics, one-based character columns
+      included, rather than raw byte offsets. A node without a position, which
+      only the synthesized ones have, maps to astx's own no-location value.
+    parameters:
+      extracted:
+        type: ExtractedSource
+      node:
+        type: ast.AST
+    returns:
+      type: astx.SourceLocation
+    """
+    located = diagnostic(extracted, node, "")
+    if located.line is None or located.column is None:
+        return NO_SOURCE_LOCATION
+    return astx.SourceLocation(line=located.line, col=located.column)
+
+
+def _astx_type(sig_type: SigType) -> AnyType:
+    """
+    title: Instantiate the astx type a signature type lowers to.
+    parameters:
+      sig_type:
+        type: SigType
+    returns:
+      type: AnyType
+    raises:
+      LoweringError: If the type names an astx class this stage does not map.
+    """
+    astx_class = _ASTX_TYPES.get(sig_type.astx_name)
+    if astx_class is None:
+        raise LoweringError(
+            f"cannot lower the {sig_type} type: no astx class is mapped for"
+            f" {sig_type.astx_name!r}"
+        )
+    return astx_class()
+
+
+class _Lowerer:
+    """
+    title: Build the astx nodes for one validated function.
+    summary: >-
+      Dispatches by node type via plum: each lowerable construct has its own
+      overload, and the ast.AST overload is the fail-closed default. Failing
+      closed matters more here than in validation, because this stage runs on a
+      function already accepted: a node with no overload means the subset and
+      the lowerer disagree, which must surface rather than silently produce a
+      module missing part of the function.
+    attributes:
+      extracted:
+        description: The extracted source being lowered.
+      signature:
+        description: The signature reconciliation settled on.
+    """
+
+    def __init__(
+        self,
+        extracted: ExtractedSource,
+        signature: Signature,
+    ) -> None:
+        """
+        title: Initialize the lowerer for one function.
+        parameters:
+          extracted:
+            type: ExtractedSource
+          signature:
+            type: Signature
+        """
+        self.extracted = extracted
+        self.signature = signature
+
+    def _reject(self, node: ast.AST, message: str) -> LoweringError:
+        """
+        title: Build a LoweringError located at an ast node.
+        summary: >-
+          Returned rather than raised so callers raise at the point of failure
+          and the traceback names the overload that could not proceed.
+        parameters:
+          node:
+            type: ast.AST
+          message:
+            type: str
+        returns:
+          type: LoweringError
+        """
+        return LoweringError(
+            message, diagnostics=[diagnostic(self.extracted, node, message)]
+        )
+
+    @dispatch
+    def statement(self, node: ast.AST) -> astx.AST | None:
+        """
+        title: Reject any statement with no overload (fail closed).
+        parameters:
+          node:
+            type: ast.AST
+        returns:
+          type: astx.AST | None
+        raises:
+          LoweringError: Always.
+        """
+        kind = type(node).__name__
+        raise self._reject(
+            node, f"cannot lower a {kind} statement to astx yet"
+        )
+
+    @dispatch
+    def statement(self, node: ast.Pass) -> astx.AST | None:
+        """
+        title: Lower a pass statement to nothing.
+        summary: >-
+          It has no effect to compile, so it contributes no node rather than an
+          empty one.
+        parameters:
+          node:
+            type: ast.Pass
+        returns:
+          type: astx.AST | None
+        """
+        return None
+
+    @dispatch
+    def statement(self, node: ast.Expr) -> astx.AST | None:
+        """
+        title: Lower a docstring or no-op string statement to nothing.
+        summary: >-
+          Validation admits a bare string statement and nothing else in this
+          position, so the string is discarded and anything else is a
+          disagreement between the two stages.
+        parameters:
+          node:
+            type: ast.Expr
+        returns:
+          type: astx.AST | None
+        """
+        if isinstance(node.value, ast.Constant) and isinstance(
+            node.value.value, str
+        ):
+            return None
+        raise self._reject(
+            node, "cannot lower a standalone expression statement to astx"
+        )
+
+    @dispatch
+    def statement(self, node: ast.Return) -> astx.AST | None:
+        """
+        title: Lower a return statement.
+        summary: >-
+          A bare return leaves a function with a declared return type without a
+          value, which no signature this stage can be given describes, so it is
+          rejected rather than lowered to a return of nothing.
+        parameters:
+          node:
+            type: ast.Return
+        returns:
+          type: astx.AST | None
+        raises:
+          LoweringError: If the return has no value.
+        """
+        if node.value is None:
+            raise self._reject(
+                node,
+                f"cannot lower a bare return: {self.extracted.node.name!r}"
+                f" declares the return type {self.signature.return_type}",
+            )
+        return astx.FunctionReturn(
+            self.expression(node.value),
+            loc=_location(self.extracted, node),
+        )
+
+    @dispatch
+    def expression(self, node: ast.AST) -> astx.DataType:
+        """
+        title: Reject any expression with no overload (fail closed).
+        parameters:
+          node:
+            type: ast.AST
+        returns:
+          type: astx.DataType
+        raises:
+          LoweringError: Always.
+        """
+        kind = type(node).__name__
+        raise self._reject(
+            node, f"cannot lower a {kind} expression to astx yet"
+        )
+
+    @dispatch
+    def expression(self, node: ast.Constant) -> astx.DataType:
+        """
+        title: Lower an int, float, or bool literal.
+        summary: >-
+          The literal's own Python type picks the astx class, not the declared
+          signature type: IRx owns semantic analysis, so a literal narrower or
+          wider than its context is its business to check and cast, and
+          lowering states only what the source says. The practical consequence
+          is that a literal is always 64-bit, since Python has no narrower
+          numeric literal, and an i32 or f32 function relies on IRx to convert.
+        parameters:
+          node:
+            type: ast.Constant
+        returns:
+          type: astx.DataType
+        raises:
+          LoweringError: If the literal is not an int, float, or bool.
+        """
+        for python_type, literal_class in _LITERAL_TYPES:
+            if isinstance(node.value, python_type):
+                return literal_class(
+                    node.value, loc=_location(self.extracted, node)
+                )
+        kind = type(node.value).__name__
+        raise self._reject(node, f"cannot lower a {kind} literal to astx")
+
+    def arguments(self) -> astx.Arguments:
+        """
+        title: Build the typed argument list from the signature.
+        summary: >-
+          The names come from the definition and the types from the signature,
+          which is what makes an explicit signature= able to decide types
+          without the function having to annotate. Reconciliation has already
+          checked the two agree in count, but lower is public and zip would
+          silently drop the excess on either side, so the count is confirmed
+          rather than assumed: a module missing an argument would compile to a
+          calling convention no caller could satisfy.
+        returns:
+          type: astx.Arguments
+        raises:
+          LoweringError: If the signature and the definition disagree in count.
+        """
+        parameters = [
+            *self.extracted.node.args.posonlyargs,
+            *self.extracted.node.args.args,
+        ]
+        declared = len(self.signature.arg_types)
+        if declared != len(parameters):
+            plural = "" if declared == 1 else "s"
+            raise self._reject(
+                self.extracted.node,
+                f"cannot lower {self.extracted.node.name!r}: the signature"
+                f" declares {declared} argument type{plural} but it takes"
+                f" {len(parameters)} parameters",
+            )
+        return astx.Arguments(
+            *(
+                astx.Argument(
+                    name=parameter.arg,
+                    type_=_astx_type(sig_type),
+                    loc=_location(self.extracted, parameter),
+                )
+                for parameter, sig_type in zip(
+                    parameters, self.signature.arg_types
+                )
+            )
+        )
+
+    def body(self) -> astx.Block:
+        """
+        title: Lower the function body into an astx block.
+        summary: >-
+          Statements that compile to nothing, a docstring or a pass, are
+          dropped rather than represented, so the block holds only what IRx has
+          to translate.
+        returns:
+          type: astx.Block
+        """
+        block = astx.Block()
+        for node in self.extracted.node.body:
+            lowered = self.statement(node)
+            if lowered is not None:
+                block.append(lowered)
+        return block
+
+
+def lower(extracted: ExtractedSource, signature: Signature) -> astx.Module:
+    """
+    title: Lower a validated function into a single-function astx module.
+    summary: >-
+      Takes the function ast from arxjit.source and the Signature from
+      arxjit.reconcile, and returns the astx module IRx compiles. The module is
+      named after the function so a compiled artifact is identifiable, and
+      holds exactly one function definition: arxjit compiles one decorated
+      function at a time. Both inputs are expected to have passed their own
+      stage; anything this stage cannot map is a LoweringError rather than a
+      user-facing rejection.
+    parameters:
+      extracted:
+        type: ExtractedSource
+        description: A function that has already passed validation.
+      signature:
+        type: Signature
+        description: The signature resolve_signature settled on.
+    returns:
+      type: astx.Module
+    raises:
+      LoweringError: If any part of the function has no astx mapping yet.
+    """
+    lowerer = _Lowerer(extracted, signature)
+    node = extracted.node
+    loc = _location(extracted, node)
+    prototype = astx.FunctionPrototype(
+        name=node.name,
+        args=lowerer.arguments(),
+        return_type=_astx_type(signature.return_type),
+        loc=loc,
+    )
+    module = astx.Module(name=node.name)
+    module.block.append(
+        astx.FunctionDef(prototype=prototype, body=lowerer.body(), loc=loc)
+    )
+    return module
+
+
+__all__ = ["lower"]

--- a/packages/arxjit/src/arxjit/lowering.py
+++ b/packages/arxjit/src/arxjit/lowering.py
@@ -16,6 +16,9 @@ summary: >-
 from __future__ import annotations
 
 import ast
+import struct
+
+from typing import NamedTuple
 
 import astx
 
@@ -27,39 +30,83 @@ import astx
 from astx.base import NO_SOURCE_LOCATION
 from astx.types.base import AnyType
 from plum import dispatch
+from public import private
 
 from arxjit.errors import LoweringError
 from arxjit.locations import diagnostic
 from arxjit.source import ExtractedSource
 from arxjit.types import Signature, SigType
 
-# Bound by SigType.astx_name, which keeps arxjit.types free of any astx
+
+class _Scalar(NamedTuple):
+    """
+    title: Everything this stage needs to lower a value at one scalar type.
+    summary: >-
+      Held together in one row rather than in parallel tables so the parts
+      cannot drift: a type with no literal class, or an integer type with no
+      range to check against, is not expressible here.
+    attributes:
+      type_:
+        type: type[AnyType]
+        description: The astx type class, used for arguments and returns.
+      literal:
+        type: type[astx.Literal]
+        description: The astx literal class values are built with.
+      kind:
+        type: str
+        description: Which Python literals belong here; bool, int, or float.
+      bounds:
+        type: tuple[int, int] | None
+        description: The representable integer range, for integer types.
+      single:
+        type: bool
+        description: Whether the type has single rather than double precision.
+    """
+
+    type_: type[AnyType]
+    literal: type[astx.Literal]
+    kind: str
+    bounds: tuple[int, int] | None
+    single: bool
+
+
+# Keyed by SigType.astx_name, which keeps arxjit.types free of any astx
 # import: the type API names its astx target, and this stage is where that
 # name becomes a class. Every SigType arxjit exports must appear here, which
-# test_every_sig_type_has_an_astx_class pins.
-_ASTX_TYPES: dict[str, type[AnyType]] = {
-    "Boolean": astx.Boolean,
-    "Float32": astx.Float32,
-    "Float64": astx.Float64,
-    "Int32": astx.Int32,
-    "Int64": astx.Int64,
+# test_every_sig_type_is_mapped pins.
+#
+# A literal is built at the width its context declares, not at the width
+# Python happens to give it. IRx only inserts safe widening conversions and
+# rejects Int64 -> Int32 and Float64 -> Float32 outright, so emitting every
+# integer as Int64 would make an i32 function fail semantic analysis on a
+# literal the user wrote perfectly correctly. Python integers are also
+# unbounded, so a value has to be checked against the range it is lowered
+# into rather than assumed to fit.
+_SCALARS: dict[str, _Scalar] = {
+    "Boolean": _Scalar(astx.Boolean, astx.LiteralBoolean, "bool", None, False),
+    "Float32": _Scalar(astx.Float32, astx.LiteralFloat32, "float", None, True),
+    "Float64": _Scalar(
+        astx.Float64, astx.LiteralFloat64, "float", None, False
+    ),
+    "Int32": _Scalar(
+        astx.Int32, astx.LiteralInt32, "int", (-(2**31), 2**31 - 1), False
+    ),
+    "Int64": _Scalar(
+        astx.Int64, astx.LiteralInt64, "int", (-(2**63), 2**63 - 1), False
+    ),
 }
 
-# Ordered, and checked in order, because bool is a subclass of int in Python:
-# a True literal matches int too, and would lower to an integer without this.
-# Widths are the Python defaults rather than the signature's type; see the
-# ast.Constant overload for why the declared type deliberately does not drive
-# this.
-_LITERAL_TYPES: tuple[tuple[type, type[astx.Literal]], ...] = (
-    (bool, astx.LiteralBoolean),
-    (int, astx.LiteralInt64),
-    (float, astx.LiteralFloat64),
-)
+# IRx reserves "main" as the program entry point and requires it to take no
+# parameters and return Int32, so a decorated Python function of that name
+# cannot be emitted under its own name. Kept as a literal rather than imported
+# from irx.analysis.registry so that importing arxjit does not pull in the
+# compiler; test_reserved_names_match_irx pins the two together.
+_RESERVED_NAMES = frozenset({"main"})
+_MANGLE_PREFIX = "arxjit_"
 
 
-def _location(
-    extracted: ExtractedSource, node: ast.AST
-) -> astx.SourceLocation:
+@private
+def location(extracted: ExtractedSource, node: ast.AST) -> astx.SourceLocation:
     """
     title: Convert an ast node's position into an astx source location.
     summary: >-
@@ -81,7 +128,29 @@ def _location(
     return astx.SourceLocation(line=located.line, col=located.column)
 
 
-def _astx_type(sig_type: SigType) -> AnyType:
+@private
+def scalar(sig_type: SigType) -> _Scalar:
+    """
+    title: Look up everything needed to lower values at a signature type.
+    parameters:
+      sig_type:
+        type: SigType
+    returns:
+      type: _Scalar
+    raises:
+      LoweringError: If the type names an astx class this stage does not map.
+    """
+    mapped = _SCALARS.get(sig_type.astx_name)
+    if mapped is None:
+        raise LoweringError(
+            f"cannot lower the {sig_type} type: no astx class is mapped for"
+            f" {sig_type.astx_name!r}"
+        )
+    return mapped
+
+
+@private
+def astx_type(sig_type: SigType) -> AnyType:
     """
     title: Instantiate the astx type a signature type lowers to.
     parameters:
@@ -92,16 +161,65 @@ def _astx_type(sig_type: SigType) -> AnyType:
     raises:
       LoweringError: If the type names an astx class this stage does not map.
     """
-    astx_class = _ASTX_TYPES.get(sig_type.astx_name)
-    if astx_class is None:
-        raise LoweringError(
-            f"cannot lower the {sig_type} type: no astx class is mapped for"
-            f" {sig_type.astx_name!r}"
-        )
-    return astx_class()
+    return scalar(sig_type).type_()
 
 
-class _Lowerer:
+@private
+def function_name(python_name: str) -> str:
+    """
+    title: Return the astx function name a Python function is emitted under.
+    summary: >-
+      Usually the Python name unchanged, so IR dumps and compiled symbols stay
+      recognisable. A name IRx reserves for the program entry point is prefixed
+      instead: a decorated function called main is an ordinary compiled
+      function, but emitting it under that name would subject it to IRx's
+      entry-point rules, which demand no parameters and an Int32 return.
+    parameters:
+      python_name:
+        type: str
+    returns:
+      type: str
+    """
+    if python_name in _RESERVED_NAMES:
+        return f"{_MANGLE_PREFIX}{python_name}"
+    return python_name
+
+
+@private
+def representable(value: float, single: bool) -> bool:
+    """
+    title: Report whether a float value survives the target's precision.
+    summary: |-
+      Python floats are doubles, so only a single-precision target can
+      overflow. Packing and unpacking is the exact test. Loss of precision,
+      including underflow to zero, is not overflow and is accepted, because
+      narrowing a float always loses precision and rejecting that would rule
+      out most decimals.
+      How struct reports an overflow is not portable: the same value packs to
+      an infinity on some builds and raises OverflowError on others, and this
+      differs between platforms at one CPython version rather than only
+      between versions. Both are the same answer, so both are handled here;
+      letting the exception escape would also turn a rejectable literal into a
+      raw stdlib error rather than a diagnostic.
+    parameters:
+      value:
+        type: float
+      single:
+        type: bool
+    returns:
+      type: bool
+    """
+    if not single:
+        return True
+    try:
+        packed: float = struct.unpack("f", struct.pack("f", value))[0]
+    except OverflowError:
+        return False
+    return packed == value or packed not in (float("inf"), float("-inf"))
+
+
+@private
+class Lowerer:
     """
     title: Build the astx nodes for one validated function.
     summary: >-
@@ -134,7 +252,8 @@ class _Lowerer:
         self.extracted = extracted
         self.signature = signature
 
-    def _reject(self, node: ast.AST, message: str) -> LoweringError:
+    @private
+    def reject(self, node: ast.AST, message: str) -> LoweringError:
         """
         title: Build a LoweringError located at an ast node.
         summary: >-
@@ -165,9 +284,7 @@ class _Lowerer:
           LoweringError: Always.
         """
         kind = type(node).__name__
-        raise self._reject(
-            node, f"cannot lower a {kind} statement to astx yet"
-        )
+        raise self.reject(node, f"cannot lower a {kind} statement to astx yet")
 
     @dispatch
     def statement(self, node: ast.Pass) -> astx.AST | None:
@@ -202,7 +319,7 @@ class _Lowerer:
             node.value.value, str
         ):
             return None
-        raise self._reject(
+        raise self.reject(
             node, "cannot lower a standalone expression statement to astx"
         )
 
@@ -211,9 +328,11 @@ class _Lowerer:
         """
         title: Lower a return statement.
         summary: >-
-          A bare return leaves a function with a declared return type without a
-          value, which no signature this stage can be given describes, so it is
-          rejected rather than lowered to a return of nothing.
+          The value is lowered against the signature's return type, which is
+          the type the returned expression is required to have. A bare return
+          leaves a function with a declared return type without a value, which
+          no signature this stage can be given describes, so it is rejected
+          rather than lowered to a return of nothing.
         parameters:
           node:
             type: ast.Return
@@ -223,59 +342,187 @@ class _Lowerer:
           LoweringError: If the return has no value.
         """
         if node.value is None:
-            raise self._reject(
+            raise self.reject(
                 node,
                 f"cannot lower a bare return: {self.extracted.node.name!r}"
                 f" declares the return type {self.signature.return_type}",
             )
         return astx.FunctionReturn(
-            self.expression(node.value),
-            loc=_location(self.extracted, node),
+            self.expression(node.value, self.signature.return_type),
+            loc=location(self.extracted, node),
         )
 
     @dispatch
-    def expression(self, node: ast.AST) -> astx.DataType:
+    def expression(self, node: ast.AST, expected: SigType) -> astx.DataType:
         """
         title: Reject any expression with no overload (fail closed).
         parameters:
           node:
             type: ast.AST
+          expected:
+            type: SigType
         returns:
           type: astx.DataType
         raises:
           LoweringError: Always.
         """
         kind = type(node).__name__
-        raise self._reject(
+        raise self.reject(
             node, f"cannot lower a {kind} expression to astx yet"
         )
 
     @dispatch
-    def expression(self, node: ast.Constant) -> astx.DataType:
+    def expression(
+        self, node: ast.Constant, expected: SigType
+    ) -> astx.DataType:
         """
-        title: Lower an int, float, or bool literal.
+        title: Lower an int, float, or bool literal at its expected type.
         summary: >-
-          The literal's own Python type picks the astx class, not the declared
-          signature type: IRx owns semantic analysis, so a literal narrower or
-          wider than its context is its business to check and cast, and
-          lowering states only what the source says. The practical consequence
-          is that a literal is always 64-bit, since Python has no narrower
-          numeric literal, and an i32 or f32 function relies on IRx to convert.
+          The literal is built at the width its context declares rather than at
+          Python's own, because IRx only inserts safe widening conversions: an
+          Int64 literal in an i32 function is rejected outright, not narrowed.
+          The value still has to belong to that type, so a literal of the wrong
+          kind, or one outside the type's range, is refused here instead of
+          becoming an astx node that misstates its own value.
         parameters:
           node:
             type: ast.Constant
+          expected:
+            type: SigType
         returns:
           type: astx.DataType
         raises:
-          LoweringError: If the literal is not an int, float, or bool.
+          LoweringError: If the literal's kind or value does not fit.
         """
-        for python_type, literal_class in _LITERAL_TYPES:
-            if isinstance(node.value, python_type):
-                return literal_class(
-                    node.value, loc=_location(self.extracted, node)
+        target = scalar(expected)
+        value = self._literal_value(node, expected, target)
+        return target.literal(value, loc=location(self.extracted, node))
+
+    def _literal_value(
+        self, node: ast.Constant, expected: SigType, target: _Scalar
+    ) -> bool | int | float:
+        """
+        title: Check a literal against its expected type and convert it.
+        summary: >-
+          bool is checked before int because it is a subclass of one: without
+          that order True would satisfy an integer context. An integer in a
+          float context is converted, which is the widening Python itself
+          performs; the reverse is not, because a float has no integer value to
+          preserve. Note that a negative literal never arrives here as one:
+          Python parses it as a unary minus applied to a positive constant, so
+          when that operator is lowered the range check has to be applied to
+          the negated value, or the exact minimum of a signed type would be
+          refused for exceeding its own maximum.
+        parameters:
+          node:
+            type: ast.Constant
+          expected:
+            type: SigType
+          target:
+            type: _Scalar
+        returns:
+          type: bool | int | float
+        raises:
+          LoweringError: If the literal's kind or value does not fit.
+        """
+        value = node.value
+        if isinstance(value, bool):
+            if target.kind != "bool":
+                raise self.reject(
+                    node, f"cannot lower a bool literal as {expected}"
                 )
-        kind = type(node.value).__name__
-        raise self._reject(node, f"cannot lower a {kind} literal to astx")
+            return value
+        if isinstance(value, int):
+            # The one kind that also belongs in a float context.
+            if target.kind == "int":
+                return self._in_range(node, value, expected, target)
+            if target.kind == "float":
+                return self._as_float(node, value, expected, target)
+            raise self.reject(
+                node, f"cannot lower an int literal as {expected}"
+            )
+        if isinstance(value, float):
+            if target.kind != "float":
+                raise self.reject(
+                    node, f"cannot lower a float literal as {expected}"
+                )
+            return self._as_float(node, value, expected, target)
+        name = type(value).__name__
+        raise self.reject(node, f"cannot lower a {name} literal to astx")
+
+    def _in_range(
+        self,
+        node: ast.Constant,
+        value: int,
+        expected: SigType,
+        target: _Scalar,
+    ) -> int:
+        """
+        title: Check an integer literal fits the integer type it lowers into.
+        summary: >-
+          Python integers are unbounded, so a value has to be checked rather
+          than assumed to fit: without this one too large to represent would
+          still be labelled Int64 and misstate its own value.
+        parameters:
+          node:
+            type: ast.Constant
+          value:
+            type: int
+          expected:
+            type: SigType
+          target:
+            type: _Scalar
+        returns:
+          type: int
+        raises:
+          LoweringError: If the value is outside the type's range.
+        """
+        assert target.bounds is not None
+        low, high = target.bounds
+        if not low <= value <= high:
+            raise self.reject(
+                node, f"the literal {value!r} is out of range for {expected}"
+            )
+        return value
+
+    def _as_float(
+        self,
+        node: ast.Constant,
+        value: int | float,
+        expected: SigType,
+        target: _Scalar,
+    ) -> float:
+        """
+        title: Convert a numeric literal to the float type it lowers into.
+        summary: >-
+          Converting an integer can overflow when it has more magnitude than a
+          double holds, and a double can exceed what a single holds, so both
+          steps are checked rather than left to produce an infinity.
+        parameters:
+          node:
+            type: ast.Constant
+          value:
+            type: int | float
+          expected:
+            type: SigType
+          target:
+            type: _Scalar
+        returns:
+          type: float
+        raises:
+          LoweringError: If the value is outside the type's range.
+        """
+        try:
+            converted = float(value)
+        except OverflowError:
+            raise self.reject(
+                node, f"the literal {value!r} is out of range for {expected}"
+            ) from None
+        if not representable(converted, target.single):
+            raise self.reject(
+                node, f"the literal {value!r} is out of range for {expected}"
+            )
+        return converted
 
     def arguments(self) -> astx.Arguments:
         """
@@ -283,24 +530,23 @@ class _Lowerer:
         summary: >-
           The names come from the definition and the types from the signature,
           which is what makes an explicit signature= able to decide types
-          without the function having to annotate. Reconciliation has already
-          checked the two agree in count, but lower is public and zip would
-          silently drop the excess on either side, so the count is confirmed
-          rather than assumed: a module missing an argument would compile to a
-          calling convention no caller could satisfy.
+          without the function having to annotate. Validation rejects every
+          shape refused here first, but lower is public and the astx argument
+          list cannot express any of them, so each is refused rather than
+          quietly dropped: a variadic or keyword-only parameter would vanish
+          from the prototype, and a default would become a required argument.
         returns:
           type: astx.Arguments
         raises:
-          LoweringError: If the signature and the definition disagree in count.
+          LoweringError: If the argument shape or count cannot be lowered.
         """
-        parameters = [
-            *self.extracted.node.args.posonlyargs,
-            *self.extracted.node.args.args,
-        ]
+        args = self.extracted.node.args
+        self._check_shape(args)
+        parameters = [*args.posonlyargs, *args.args]
         declared = len(self.signature.arg_types)
         if declared != len(parameters):
             plural = "" if declared == 1 else "s"
-            raise self._reject(
+            raise self.reject(
                 self.extracted.node,
                 f"cannot lower {self.extracted.node.name!r}: the signature"
                 f" declares {declared} argument type{plural} but it takes"
@@ -310,14 +556,58 @@ class _Lowerer:
             *(
                 astx.Argument(
                     name=parameter.arg,
-                    type_=_astx_type(sig_type),
-                    loc=_location(self.extracted, parameter),
+                    type_=astx_type(sig_type),
+                    loc=location(self.extracted, parameter),
                 )
                 for parameter, sig_type in zip(
                     parameters, self.signature.arg_types
                 )
             )
         )
+
+    def _check_shape(self, args: ast.arguments) -> None:
+        """
+        title: Reject an argument shape astx.Arguments cannot express.
+        summary: >-
+          Checked before the count, because counting the positional parameters
+          of a function that also takes *args would report a number no caller
+          could act on. Mirrors the shape check reconciliation applies, so the
+          two stages refuse the same definitions.
+        parameters:
+          args:
+            type: ast.arguments
+        raises:
+          LoweringError: >-
+            If any parameter is variadic, keyword-only, or has a default.
+        """
+        offender = next(
+            (
+                node
+                for node in (args.vararg, args.kwarg, *args.kwonlyargs)
+                if node is not None
+            ),
+            None,
+        )
+        if offender is not None:
+            raise self.reject(
+                offender,
+                "cannot lower a variadic or keyword-only parameter: only"
+                " positional parameters are supported",
+            )
+        default = next(
+            (
+                node
+                for node in (*args.defaults, *args.kw_defaults)
+                if node is not None
+            ),
+            None,
+        )
+        if default is not None:
+            raise self.reject(
+                default,
+                "cannot lower a parameter default: it would become a required"
+                " argument",
+            )
 
     def body(self) -> astx.Block:
         """
@@ -342,12 +632,13 @@ def lower(extracted: ExtractedSource, signature: Signature) -> astx.Module:
     title: Lower a validated function into a single-function astx module.
     summary: >-
       Takes the function ast from arxjit.source and the Signature from
-      arxjit.reconcile, and returns the astx module IRx compiles. The module is
-      named after the function so a compiled artifact is identifiable, and
-      holds exactly one function definition: arxjit compiles one decorated
-      function at a time. Both inputs are expected to have passed their own
-      stage; anything this stage cannot map is a LoweringError rather than a
-      user-facing rejection.
+      arxjit.reconcile, and returns the astx module IRx compiles. The module
+      keeps the Python function's name so a compiled artifact is identifiable,
+      and holds exactly one function definition: arxjit compiles one decorated
+      function at a time. The definition itself may be emitted under a
+      different name; see function_name. Both inputs are expected to have
+      passed their own stage, so anything this stage cannot map is a
+      LoweringError rather than a user-facing rejection.
     parameters:
       extracted:
         type: ExtractedSource
@@ -360,13 +651,13 @@ def lower(extracted: ExtractedSource, signature: Signature) -> astx.Module:
     raises:
       LoweringError: If any part of the function has no astx mapping yet.
     """
-    lowerer = _Lowerer(extracted, signature)
+    lowerer = Lowerer(extracted, signature)
     node = extracted.node
-    loc = _location(extracted, node)
+    loc = location(extracted, node)
     prototype = astx.FunctionPrototype(
-        name=node.name,
+        name=function_name(node.name),
         args=lowerer.arguments(),
-        return_type=_astx_type(signature.return_type),
+        return_type=astx_type(signature.return_type),
         loc=loc,
     )
     module = astx.Module(name=node.name)

--- a/packages/arxjit/tests/test_lowering.py
+++ b/packages/arxjit/tests/test_lowering.py
@@ -10,11 +10,20 @@ import arxjit
 import astx
 import pytest
 
+from arxjit import lowering
 from arxjit.errors import LoweringError
-from arxjit.lowering import _ASTX_TYPES, _location, lower
+from arxjit.lowering import (
+    _MANGLE_PREFIX,
+    _RESERVED_NAMES,
+    _SCALARS,
+    location,
+    lower,
+)
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.types import Signature, SigType, bool_, f32, f64, i32, i64
 from astx.base import NO_SOURCE_LOCATION
+from irx.analysis.api import analyze
+from irx.analysis.registry import MAIN_FUNCTION_NAME
 
 PyFunc = Callable[..., Any]
 
@@ -139,69 +148,268 @@ def test_positional_only_parameters_are_lowered() -> None:
 
 
 @pytest.mark.parametrize(
-    ("literal", "expected", "value"),
+    ("literal", "sig_type", "expected", "value"),
     [
-        ("1", astx.LiteralInt64, 1),
-        ("1.5", astx.LiteralFloat64, 1.5),
-        ("True", astx.LiteralBoolean, True),
-        ("False", astx.LiteralBoolean, False),
+        ("1", i32, astx.LiteralInt32, 1),
+        ("1", i64, astx.LiteralInt64, 1),
+        ("1", f32, astx.LiteralFloat32, 1.0),
+        ("1", f64, astx.LiteralFloat64, 1.0),
+        ("1.5", f32, astx.LiteralFloat32, 1.5),
+        ("1.5", f64, astx.LiteralFloat64, 1.5),
+        ("True", bool_, astx.LiteralBoolean, True),
+        ("False", bool_, astx.LiteralBoolean, False),
     ],
 )
-def test_literals_lower_by_their_own_python_type(
+def test_a_literal_is_built_at_its_expected_type(
     literal: str,
+    sig_type: SigType,
     expected: type[astx.Literal],
     value: object,
 ) -> None:
     """
-    title: Each supported literal maps to the matching astx literal class.
+    title: A literal takes the width of the type its context declares.
     summary: >-
-      True and False are covered separately from the integers because bool is a
-      subclass of int in Python: a boolean matches the int check too, so an
-      unordered mapping would lower it as an integer.
+      IRx only inserts safe widening conversions, so a literal emitted at
+      Python's own width would make an i32 or f32 function fail semantic
+      analysis. An integer in a float context is converted, which is the
+      widening Python itself performs.
     parameters:
       literal:
         type: str
+      sig_type:
+        type: SigType
       expected:
         type: type[astx.Literal]
       value:
         type: object
     """
     source = f"def sample():\n    return {literal}\n"
-    definition = _from_source(source, i64())
+    definition = _from_source(source, sig_type())
     (returned,) = definition.body.nodes
     assert isinstance(returned, astx.FunctionReturn)
     assert isinstance(returned.value, expected)
     assert returned.value.value == value
 
 
-def test_a_boolean_literal_is_not_lowered_as_an_integer() -> None:
+@pytest.mark.parametrize("sig_type", [bool_, f32, f64, i32, i64])
+def test_a_lowered_function_passes_irx_semantic_analysis(
+    sig_type: SigType,
+) -> None:
     """
-    title: A bool literal never lowers to an integer literal.
+    title: Every exported scalar type survives IRx analysis end to end.
     summary: >-
-      Pins the ordering of the literal table directly rather than only through
-      the class assertion above: isinstance(True, int) is true, so a table
-      checked in the wrong order silently produces LiteralInt64(True), which
-      compares equal to LiteralInt64(1) on value alone.
+      The cross-stage check that pins lowering to what IRx actually accepts
+      rather than to what this package believes about it. Both the entry-point
+      collision and the literal width policy were found by running analysis on
+      a lowered module, and neither is observable from the astx tree alone.
+    parameters:
+      sig_type:
+        type: SigType
     """
-    definition = _from_source("def sample():\n    return True\n", bool_())
-    (returned,) = definition.body.nodes
-    assert isinstance(returned, astx.FunctionReturn)
-    assert not isinstance(returned.value, astx.LiteralInt64)
+    literal = "True" if sig_type is bool_ else "1"
+    source = f"def sample():\n    return {literal}\n"
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    module = lower(
+        ExtractedSource(filename="<test>", source=source, lineno=1, node=node),
+        sig_type(),
+    )
+    analyze(module)
 
 
-def test_the_declared_type_does_not_narrow_a_literal() -> None:
+def test_a_function_named_main_does_not_become_the_irx_entry_point() -> None:
     """
-    title: An i32 signature still yields a 64-bit literal.
+    title: A decorated function called main is emitted under another name.
     summary: >-
-      Pins the documented division of labour: lowering states what the source
-      says and IRx owns conversion, so the literal keeps the only width Python
-      can express rather than being narrowed to match the signature.
+      IRx reserves main for the program entry point and requires it to take no
+      parameters and return Int32, so lowering it under its own name makes an
+      otherwise valid function fail analysis. Analysis is run here because the
+      rule being avoided is IRx's, not this package's.
     """
-    definition = _from_source("def sample():\n    return 7\n", i32())
+    source = "def main():\n    return 1\n"
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    module = lower(
+        ExtractedSource(filename="<test>", source=source, lineno=1, node=node),
+        i64(),
+    )
+    definition = module.block[0]
+    assert isinstance(definition, astx.FunctionDef)
+    assert definition.prototype.name == f"{_MANGLE_PREFIX}main"
+    assert module.name == "main"
+    analyze(module)
+
+
+def test_an_ordinary_name_is_not_mangled() -> None:
+    """
+    title: Only a reserved name is renamed.
+    summary: >-
+      The control for the test above: mangling every function would make IR
+      dumps and compiled symbols harder to recognise for no benefit.
+    """
+    definition = _from_source("def sample():\n    return 1\n", i64())
+    assert definition.prototype.name == "sample"
+
+
+def test_reserved_names_match_irx() -> None:
+    """
+    title: The reserved-name list agrees with IRx's own constant.
+    summary: >-
+      The list is duplicated rather than imported so that importing arxjit does
+      not pull in the compiler. This keeps the copy honest: if IRx renames or
+      adds an entry point, this fails rather than the mangling quietly ceasing
+      to apply.
+    """
+    assert MAIN_FUNCTION_NAME in _RESERVED_NAMES
+
+
+@pytest.mark.parametrize(
+    ("literal", "sig_type"),
+    [
+        ("True", i64),
+        ("True", f64),
+        ("1", bool_),
+        ("1.5", i64),
+        ("1.5", bool_),
+    ],
+)
+def test_a_literal_of_the_wrong_kind_is_rejected(
+    literal: str, sig_type: SigType
+) -> None:
+    """
+    title: A literal must belong to the type its context declares.
+    summary: >-
+      bool is checked before int because it is a subclass of one, so True must
+      not satisfy an integer context by accident. A float in an integer context
+      has no integer value to preserve, so it is refused rather than truncated.
+    parameters:
+      literal:
+        type: str
+      sig_type:
+        type: SigType
+    """
+    source = f"def sample():\n    return {literal}\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, sig_type())
+    assert "cannot lower a" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("literal", "sig_type"),
+    [
+        (str(2**31), i32),
+        (str(2**63), i64),
+        (str(2**2000), f64),
+        ("1e39", f32),
+    ],
+)
+def test_a_literal_out_of_range_is_rejected(
+    literal: str, sig_type: SigType
+) -> None:
+    """
+    title: A literal too large for its type is refused, not mislabelled.
+    summary: >-
+      Python integers are unbounded, so without a range check a value too large
+      to represent would still be emitted as an Int64 literal that misstates
+      its own value. The float cases cover the two ways a value can exceed a
+      target: an integer beyond what a double can hold, and a double beyond
+      what a single can.
+    parameters:
+      literal:
+        type: str
+      sig_type:
+        type: SigType
+    """
+    source = f"def sample():\n    return {literal}\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, sig_type())
+    assert "out of range" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("literal", "sig_type"),
+    [
+        (str(2**31 - 1), i32),
+        (str(2**63 - 1), i64),
+        ("3.4e38", f32),
+        ("1e-50", f32),
+    ],
+)
+def test_a_literal_at_the_edge_of_range_is_accepted(
+    literal: str, sig_type: SigType
+) -> None:
+    """
+    title: The range check admits the extremes it is meant to admit.
+    summary: >-
+      The boundary partner of the rejection test: an off-by-one bound would
+      pass that test while refusing values the type represents perfectly well.
+      Underflow to zero is precision loss rather than overflow, so a tiny float
+      is accepted.
+    parameters:
+      literal:
+        type: str
+      sig_type:
+        type: SigType
+    """
+    source = f"def sample():\n    return {literal}\n"
+    definition = _from_source(source, sig_type())
     (returned,) = definition.body.nodes
     assert isinstance(returned, astx.FunctionReturn)
-    assert isinstance(returned.value, astx.LiteralInt64)
-    assert isinstance(definition.prototype.return_type, astx.Int32)
+
+
+def test_a_float_overflow_reported_by_exception_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    title: An overflow raised rather than returned is still a rejection.
+    summary: >-
+      struct reports a value too large for single precision either by packing
+      it to an infinity or by raising OverflowError, and which one is not
+      portable: the same CPython version does one on some platforms and the
+      other elsewhere. The real out-of-range case above therefore exercises
+      only one of the two paths on any given machine, so the other is forced
+      here, and both are covered on every cell of the matrix.
+    parameters:
+      monkeypatch:
+        type: pytest.MonkeyPatch
+    """
+
+    def raising(fmt: str, value: float) -> bytes:
+        """
+        title: Stand in for struct.pack, always overflowing.
+        parameters:
+          fmt:
+            type: str
+          value:
+            type: float
+        returns:
+          type: bytes
+        raises:
+          OverflowError: Always.
+        """
+        raise OverflowError("float too large to pack with f format")
+
+    monkeypatch.setattr(lowering.struct, "pack", raising)
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source("def sample():\n    return 1.5\n", f32())
+    assert "out of range" in str(excinfo.value)
+
+
+def test_a_negative_literal_is_not_a_literal_yet() -> None:
+    """
+    title: A negative number reaches this stage as a unary minus.
+    summary: >-
+      Pinned because it is a trap for the operator lowering that follows.
+      Python parses -1 as USub applied to the constant 1, so no negative value
+      ever reaches the constant overload, and the range check only ever sees
+      the magnitude. Applying that check before the negation would refuse the
+      exact minimum of a signed type, which is one larger in magnitude than its
+      maximum: -2147483648 is a valid i32 while 2147483648 is not.
+    """
+    source = f"def sample():\n    return -{2**31}\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i32())
+    assert "cannot lower a UnaryOp expression" in str(excinfo.value)
 
 
 def test_docstring_and_pass_lower_to_nothing() -> None:
@@ -266,7 +474,7 @@ def test_a_node_without_a_position_maps_to_no_location() -> None:
     extracted = ExtractedSource(
         filename="<test>", source=source, lineno=1, node=node
     )
-    assert _location(extracted, ast.Pass()) is NO_SOURCE_LOCATION
+    assert location(extracted, ast.Pass()) is NO_SOURCE_LOCATION
 
 
 def test_bare_return_is_rejected() -> None:
@@ -329,6 +537,44 @@ def test_an_unsupported_literal_is_rejected() -> None:
     assert "cannot lower a str literal" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    ("source", "signature", "expected"),
+    [
+        ("def sample(*args):\n    return 1\n", i64(), "variadic"),
+        ("def sample(**kwargs):\n    return 1\n", i64(), "variadic"),
+        ("def sample(*, k):\n    return 1\n", i64(), "variadic"),
+        ("def sample(x=1):\n    return 1\n", i64(i64), "parameter default"),
+        (
+            "def sample(*, k=1):\n    return 1\n",
+            i64(),
+            "variadic",
+        ),
+    ],
+)
+def test_an_unsupported_argument_shape_is_rejected(
+    source: str, signature: Signature, expected: str
+) -> None:
+    """
+    title: Shapes an astx argument list cannot express are refused.
+    summary: >-
+      Validation rejects all of these first, but lower is public and none of
+      them can be represented: a variadic or keyword-only parameter would
+      simply vanish from the prototype, and a default would silently become a
+      required argument. The count check alone does not catch them, because a
+      function taking only *args counts as taking none.
+    parameters:
+      source:
+        type: str
+      signature:
+        type: Signature
+      expected:
+        type: str
+    """
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, signature)
+    assert expected in str(excinfo.value)
+
+
 def test_signature_arity_disagreeing_with_the_definition_is_rejected() -> None:
     """
     title: A signature describing a different function is refused.
@@ -368,19 +614,20 @@ def test_an_unmapped_signature_type_is_rejected() -> None:
 
 
 @pytest.mark.parametrize("sig_type", [bool_, f32, f64, i32, i64])
-def test_every_sig_type_has_an_astx_class(sig_type: SigType) -> None:
+def test_every_sig_type_is_mapped(sig_type: SigType) -> None:
     """
     title: Every exported signature type can be lowered.
     summary: >-
       The table is keyed by name, so a SigType added to the public type API
-      without an entry here would only fail when someone first used it. The
-      parametrization is checked against the module below so this list cannot
-      fall behind either.
+      without an entry here would only fail when someone first used it. An
+      integer type additionally needs a declared range, without which its
+      literals could not be bounds-checked.
     parameters:
       sig_type:
         type: SigType
     """
-    assert sig_type.astx_name in _ASTX_TYPES
+    mapped = _SCALARS[sig_type.astx_name]
+    assert (mapped.bounds is not None) == (mapped.kind == "int")
 
 
 def test_the_sig_type_list_covers_the_public_type_api() -> None:
@@ -396,4 +643,4 @@ def test_the_sig_type_list_covers_the_public_type_api() -> None:
         for name in arxjit.__all__
         if isinstance(value := getattr(arxjit, name), SigType)
     }
-    assert exported == set(_ASTX_TYPES)
+    assert exported == set(_SCALARS)

--- a/packages/arxjit/tests/test_lowering.py
+++ b/packages/arxjit/tests/test_lowering.py
@@ -1,0 +1,399 @@
+"""
+title: Tests for Python AST to ASTx lowering.
+"""
+
+import ast
+
+from typing import Any, Callable
+
+import arxjit
+import astx
+import pytest
+
+from arxjit.errors import LoweringError
+from arxjit.lowering import _ASTX_TYPES, _location, lower
+from arxjit.source import ExtractedSource, extract_source
+from arxjit.types import Signature, SigType, bool_, f32, f64, i32, i64
+from astx.base import NO_SOURCE_LOCATION
+
+PyFunc = Callable[..., Any]
+
+
+def _lower(fn: PyFunc, signature: Signature) -> astx.FunctionDef:
+    """
+    title: Lower a function and return its single definition (test helper).
+    parameters:
+      fn:
+        type: PyFunc
+      signature:
+        type: Signature
+    returns:
+      type: astx.FunctionDef
+    """
+    module = lower(extract_source(fn), signature)
+    definition = module.block[0]
+    assert isinstance(definition, astx.FunctionDef)
+    return definition
+
+
+def _from_source(source: str, signature: Signature) -> astx.FunctionDef:
+    """
+    title: Lower a hand-built function definition (test helper).
+    summary: >-
+      lower is public and its stages fail closed on nodes validation would have
+      rejected first, so those paths are reached by building the source
+      directly rather than through a decorated function.
+    parameters:
+      source:
+        type: str
+      signature:
+        type: Signature
+    returns:
+      type: astx.FunctionDef
+    """
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    extracted = ExtractedSource(
+        filename="<test>", source=source, lineno=1, node=node
+    )
+    definition = lower(extracted, signature).block[0]
+    assert isinstance(definition, astx.FunctionDef)
+    return definition
+
+
+def test_literal_return_lowers_to_a_single_function_module() -> None:
+    """
+    title: A constant-returning function becomes a one-function astx module.
+    """
+
+    def answer() -> int:
+        """
+        title: Return a constant.
+        returns:
+          type: int
+        """
+        return 42
+
+    module = lower(extract_source(answer), i64())
+    assert isinstance(module, astx.Module)
+    assert module.name == "answer"
+    assert len(module.block) == 1
+
+    definition = module.block[0]
+    assert isinstance(definition, astx.FunctionDef)
+    assert definition.prototype.name == "answer"
+    assert isinstance(definition.prototype.return_type, astx.Int64)
+    assert len(definition.prototype.args.nodes) == 0
+
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.LiteralInt64)
+    assert returned.value.value == 42
+
+
+def test_arguments_take_names_from_the_def_and_types_from_the_signature() -> (
+    None
+):
+    """
+    title: Argument names come from the definition, types from the signature.
+    summary: >-
+      The signature here is deliberately not the one the annotations would
+      derive: i32 has no Python annotation that produces it, so seeing i32 on
+      the lowered arguments proves the signature drove the types.
+    """
+
+    def add(a: int, b: int) -> int:
+        """
+        title: Add two numbers.
+        parameters:
+          a:
+            type: int
+          b:
+            type: int
+        returns:
+          type: int
+        """
+        return 0
+
+    definition = _lower(add, i32(i32, i32))
+    names = [argument.name for argument in definition.prototype.args.nodes]
+    assert names == ["a", "b"]
+    for argument in definition.prototype.args.nodes:
+        assert isinstance(argument.type_, astx.Int32)
+    assert isinstance(definition.prototype.return_type, astx.Int32)
+
+
+def test_positional_only_parameters_are_lowered() -> None:
+    """
+    title: Positional-only parameters become ordinary astx arguments.
+    summary: >-
+      They are positional arguments to a compiled function, and reconciliation
+      already counts them, so lowering must not drop them.
+    """
+    source = "def sample(a, /, b):\n    return 0\n"
+    definition = _from_source(source, i64(i64, f64))
+    names = [argument.name for argument in definition.prototype.args.nodes]
+    assert names == ["a", "b"]
+    assert isinstance(definition.prototype.args.nodes[0].type_, astx.Int64)
+    assert isinstance(definition.prototype.args.nodes[1].type_, astx.Float64)
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected", "value"),
+    [
+        ("1", astx.LiteralInt64, 1),
+        ("1.5", astx.LiteralFloat64, 1.5),
+        ("True", astx.LiteralBoolean, True),
+        ("False", astx.LiteralBoolean, False),
+    ],
+)
+def test_literals_lower_by_their_own_python_type(
+    literal: str,
+    expected: type[astx.Literal],
+    value: object,
+) -> None:
+    """
+    title: Each supported literal maps to the matching astx literal class.
+    summary: >-
+      True and False are covered separately from the integers because bool is a
+      subclass of int in Python: a boolean matches the int check too, so an
+      unordered mapping would lower it as an integer.
+    parameters:
+      literal:
+        type: str
+      expected:
+        type: type[astx.Literal]
+      value:
+        type: object
+    """
+    source = f"def sample():\n    return {literal}\n"
+    definition = _from_source(source, i64())
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, expected)
+    assert returned.value.value == value
+
+
+def test_a_boolean_literal_is_not_lowered_as_an_integer() -> None:
+    """
+    title: A bool literal never lowers to an integer literal.
+    summary: >-
+      Pins the ordering of the literal table directly rather than only through
+      the class assertion above: isinstance(True, int) is true, so a table
+      checked in the wrong order silently produces LiteralInt64(True), which
+      compares equal to LiteralInt64(1) on value alone.
+    """
+    definition = _from_source("def sample():\n    return True\n", bool_())
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert not isinstance(returned.value, astx.LiteralInt64)
+
+
+def test_the_declared_type_does_not_narrow_a_literal() -> None:
+    """
+    title: An i32 signature still yields a 64-bit literal.
+    summary: >-
+      Pins the documented division of labour: lowering states what the source
+      says and IRx owns conversion, so the literal keeps the only width Python
+      can express rather than being narrowed to match the signature.
+    """
+    definition = _from_source("def sample():\n    return 7\n", i32())
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.LiteralInt64)
+    assert isinstance(definition.prototype.return_type, astx.Int32)
+
+
+def test_docstring_and_pass_lower_to_nothing() -> None:
+    """
+    title: Statements with no compiled effect contribute no astx nodes.
+    """
+
+    def nothing() -> int:
+        """
+        title: Do nothing at all.
+        returns:
+          type: int
+        """
+        pass
+
+    definition = _lower(nothing, i64())
+    assert definition.body.nodes == []
+
+
+def test_lowered_nodes_carry_real_file_locations() -> None:
+    """
+    title: astx nodes are located at the user's real source position.
+    summary: >-
+      Locations run through the same builder arxjit reports diagnostics with,
+      so a compiled artifact points back at the file the user wrote, with the
+      one-based character columns Diagnostic documents rather than ast's raw
+      byte offsets.
+    """
+
+    def sample() -> int:
+        """
+        title: Return a constant.
+        returns:
+          type: int
+        """
+        return 5
+
+    extracted = extract_source(sample)
+    definition = _lower(sample, i64())
+    assert definition.loc.line == extracted.lineno
+    assert definition.loc.col == 5
+
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    lines = extracted.source.splitlines()
+    assert lines[returned.loc.line - extracted.lineno].strip() == "return 5"
+    assert isinstance(returned.value, astx.LiteralInt64)
+    assert returned.value.loc.col > returned.loc.col
+
+
+def test_a_node_without_a_position_maps_to_no_location() -> None:
+    """
+    title: A synthesized node lowers to astx's own no-location value.
+    summary: >-
+      Every node in a parsed function carries a position, so this is the
+      fallback for a hand-built one; it maps to NO_SOURCE_LOCATION rather than
+      inventing a position that would point at unrelated source.
+    """
+    source = "def sample():\n    return 1\n"
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    extracted = ExtractedSource(
+        filename="<test>", source=source, lineno=1, node=node
+    )
+    assert _location(extracted, ast.Pass()) is NO_SOURCE_LOCATION
+
+
+def test_bare_return_is_rejected() -> None:
+    """
+    title: A return with no value cannot satisfy a declared return type.
+    """
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source("def sample():\n    return\n", i64())
+    assert "cannot lower a bare return" in str(excinfo.value)
+    assert "declares the return type i64" in str(excinfo.value)
+    (diagnostic,) = excinfo.value.diagnostics
+    assert diagnostic.line == 2
+
+
+def test_an_unlowerable_statement_fails_closed() -> None:
+    """
+    title: A statement with no overload is reported, not skipped.
+    summary: >-
+      Validation admits while loops, so reaching one here means the subset and
+      the lowerer disagree; the module must not come back quietly missing the
+      loop.
+    """
+    source = "def sample():\n    while True:\n        return 1\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i64())
+    assert "cannot lower a While statement" in str(excinfo.value)
+
+
+def test_an_unlowerable_expression_fails_closed() -> None:
+    """
+    title: An expression with no overload is reported, not skipped.
+    """
+    source = "def sample(x):\n    return x\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i64(i64))
+    assert "cannot lower a Name expression" in str(excinfo.value)
+
+
+def test_a_standalone_expression_statement_is_rejected() -> None:
+    """
+    title: Only a bare string is dropped in statement position.
+    summary: >-
+      Validation rejects any other standalone expression before lowering runs,
+      so this is reached only through the public entry point; it must not
+      discard a statement that computes something.
+    """
+    source = "def sample():\n    1 + 1\n    return 1\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i64())
+    assert "standalone expression statement" in str(excinfo.value)
+
+
+def test_an_unsupported_literal_is_rejected() -> None:
+    """
+    title: A literal outside int, float and bool has no astx mapping here.
+    """
+    source = 'def sample():\n    return "text"\n'
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i64())
+    assert "cannot lower a str literal" in str(excinfo.value)
+
+
+def test_signature_arity_disagreeing_with_the_definition_is_rejected() -> None:
+    """
+    title: A signature describing a different function is refused.
+    summary: >-
+      Reconciliation makes this unreachable through @jit, but lower is public
+      and zip would silently drop the excess, producing a module whose calling
+      convention no caller could satisfy.
+    """
+    source = "def sample(a, b):\n    return 1\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i64(i64))
+    assert "declares 1 argument type but it takes 2" in str(excinfo.value)
+
+
+def test_the_arity_message_pluralizes_the_declared_count() -> None:
+    """
+    title: The count of declared types reads correctly when it is not one.
+    summary: >-
+      The singular is covered by the test above. Both are pinned because a
+      conditional expression like this one is invisible to line coverage: the
+      unexercised branch sits on a line the other branch already ran.
+    """
+    source = "def sample(a):\n    return 1\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i64(i64, i64))
+    assert "declares 2 argument types but it takes 1" in str(excinfo.value)
+
+
+def test_an_unmapped_signature_type_is_rejected() -> None:
+    """
+    title: A SigType naming an astx class this stage lacks fails closed.
+    """
+    unknown = SigType("i128", "Int128")
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source("def sample():\n    return 1\n", unknown())
+    assert "no astx class is mapped for 'Int128'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("sig_type", [bool_, f32, f64, i32, i64])
+def test_every_sig_type_has_an_astx_class(sig_type: SigType) -> None:
+    """
+    title: Every exported signature type can be lowered.
+    summary: >-
+      The table is keyed by name, so a SigType added to the public type API
+      without an entry here would only fail when someone first used it. The
+      parametrization is checked against the module below so this list cannot
+      fall behind either.
+    parameters:
+      sig_type:
+        type: SigType
+    """
+    assert sig_type.astx_name in _ASTX_TYPES
+
+
+def test_the_sig_type_list_covers_the_public_type_api() -> None:
+    """
+    title: The exhaustiveness test above is itself exhaustive.
+    summary: >-
+      Reads the public types out of the package rather than trusting the
+      parametrized list, so adding a SigType to arxjit without adding it to
+      that list fails here instead of going unnoticed.
+    """
+    exported = {
+        value.astx_name
+        for name in arxjit.__all__
+        if isinstance(value := getattr(arxjit, name), SigType)
+    }
+    assert exported == set(_ASTX_TYPES)


### PR DESCRIPTION
Starts wiki Issue 5 (Sprint 3), the Python AST to ASTx stage. New
`arxjit.lowering` turns the ast node from extraction, plus the `Signature`
from reconciliation, into the single-function astx module IRx compiles.

```text
pure Python function
  -> source extraction       #96 / #98
  -> Python AST validation   #99 / #102
  -> signature resolution    #103
  -> ASTx lowering           this PR (function shell)
  -> IRx/LLVM compilation    not implemented
  -> native call bridge      not implemented
```

This first slice covers the function shell: the prototype, its typed
arguments, and a body of literal returns. Variables, arithmetic and control
flow follow in the next PRs of the sprint, so anything else fails closed with
the new `LoweringError`.

Failing closed matters more here than in validation, because lowering only ever
runs on a function validation already accepted. A node with no overload means
the two stages disagree, and that has to surface rather than produce a module
quietly missing part of the function.

Dispatch is by node type via plum, per the convention settled in #99.
Statements and expressions dispatch separately rather than through a single
`visit`: they return different things, and one union return type would force
every call site to re-narrow it.

### Design points for review

1. **Where each type comes from.** Argument and return types come from the
   signature, which is what lets an explicit `signature=` decide types without
   the function annotating. A literal's astx class instead comes from the
   literal's own Python type, so `return 42` lowers to `LiteralInt64` even
   under an `i32` signature. The reasoning is the Arx/IRx boundary: IRx owns
   semantic analysis, so a literal narrower or wider than its context is its
   business to check and cast, and lowering states only what the source says.
   The consequence is that literals are always 64-bit, since Python has no
   narrower numeric literal.

2. **`SigType.astx_name` stays a string**, which answers the open design point
   from #91. `arxjit.types` still imports no astx; binding those names to
   classes happens in the lowerer, where astx is needed anyway. Two tests keep
   the table exhaustive: one per exported type, and one that reads the public
   type API back out of the package so the parametrized list cannot fall
   behind it.

3. **`AnyType` and `NO_SOURCE_LOCATION` are imported from their defining
   submodules**, since astx does not re-export either at the top level. Worth
   confirming that is the intended way to reach them — neither irx nor arx
   references `NO_SOURCE_LOCATION` at all, they simply omit `loc`.

### Notes

- The lowered astx nodes carry the user's real file positions, built through
  the same helper as arxjit's diagnostics, so columns follow the one-based
  character contract pinned in #95 rather than ast's raw byte offsets.
- `@jit` does not call this stage yet, so the decorator behaves exactly as
  before. That wiring lands once the lowerer covers the whole validated
  subset.
- An arity guard was added after a self-review: `zip` would have silently
  dropped the excess when a caller passes a signature that disagrees with the
  definition. Unreachable through `@jit` because reconciliation checks it
  first, but `lower` is public, and this is the same failure mode found in
  `resolve_signature` during #103.

206 tests, arxjit coverage 100% line and branch. Verified on CPython 3.10,
3.11 and 3.14.
