### PR TITLE
feat(arxjit): lower expressions to astx

### DIFF
--- a/packages/arxjit/src/arxjit/lowering.py
+++ b/packages/arxjit/src/arxjit/lowering.py
@@ -5,12 +5,14 @@ summary: >-
   Fourth stage of the arxjit pipeline: turn the ast node of a validated
   function, plus the Signature reconciliation settled on, into the astx module
   IRx compiles. Dispatch is by node type via plum, matching the visitor
-  convention used across the Arx packages. This first version lowers the
-  function shell — the prototype, its typed arguments, and a body of literal
-  returns; variables, arithmetic, and control flow follow in later stages, and
-  until then any other construct fails closed with LoweringError. The decorator
-  does not call this stage yet, so nothing here changes what @jit does; that
-  wiring lands once the lowerer covers the whole validated subset.
+  convention used across the Arx packages. What is lowered so far is the
+  function shell — the prototype and its typed arguments — and straight-line
+  expressions: literals, parameter reads, and the arithmetic, unary and
+  comparison-free operators astx shares with IRx. Local assignments and control
+  flow follow in later stages, and until then any other construct fails closed
+  with LoweringError. The decorator does not call this stage yet, so nothing
+  here changes what @jit does; that wiring lands once the lowerer covers the
+  whole validated subset.
 """
 
 from __future__ import annotations
@@ -94,6 +96,28 @@ _SCALARS: dict[str, _Scalar] = {
     "Int64": _Scalar(
         astx.Int64, astx.LiteralInt64, "int", (-(2**63), 2**63 - 1), False
     ),
+}
+
+# The operator vocabulary astx and IRx share, taken from astx's own
+# _BINARY_OP_TYPES table: an op_code outside it specializes to no node and
+# reaches codegen as "not implemented yet". Validation admits two Python
+# operators with no entry there, ast.FloorDiv and ast.Pow, so they are
+# rejected here rather than lowered into a module that cannot be compiled;
+# test_the_operator_tables_agree_with_astx pins this table to astx's.
+_BINARY_OPS: dict[type[ast.operator], str] = {
+    ast.Add: "+",
+    ast.Sub: "-",
+    ast.Mult: "*",
+    ast.Div: "/",
+    ast.Mod: "%",
+}
+
+# Unary is narrower still. IRx implements "!", "++" and "--" and nothing
+# else, so there is no operator to lower a negation onto; ast.UAdd needs none,
+# being the identity. A negation of a literal is folded instead, which is also
+# the only way a negative constant can arrive: see _literal_value.
+_UNARY_OPS: dict[type[ast.unaryop], str] = {
+    ast.Not: "!",
 }
 
 # IRx reserves "main" as the program entry point and requires it to take no
@@ -394,12 +418,145 @@ class Lowerer:
         raises:
           LoweringError: If the literal's kind or value does not fit.
         """
+        return self.literal(node, node.value, expected)
+
+    def literal(
+        self, node: ast.expr, value: object, expected: SigType
+    ) -> astx.DataType:
+        """
+        title: Build an astx literal for a value at its expected type.
+        summary: >-
+          Takes the value separately from the node it is located at, so that a
+          negated constant can be folded through here as one literal rather
+          than lowered as an operator applied to its magnitude. That is not
+          only a convenience: it is what lets the exact minimum of a signed
+          type through, since its magnitude is one larger than the maximum.
+        parameters:
+          node:
+            type: ast.expr
+          value:
+            type: object
+          expected:
+            type: SigType
+        returns:
+          type: astx.DataType
+        raises:
+          LoweringError: If the value's kind or magnitude does not fit.
+        """
         target = scalar(expected)
-        value = self._literal_value(node, expected, target)
-        return target.literal(value, loc=location(self.extracted, node))
+        checked = self._literal_value(node, value, expected, target)
+        return target.literal(checked, loc=location(self.extracted, node))
+
+    @dispatch
+    def expression(self, node: ast.Name, expected: SigType) -> astx.DataType:
+        """
+        title: Lower a variable read.
+        summary: >-
+          Only the parameters are in scope at this stage, and their types are
+          already declared on the prototype, so the reference carries no type
+          of its own and IRx resolves it from the declaration. The expected
+          type is therefore not applied here: unlike a literal, a variable has
+          the type it was given, and reconciling it with its context is IRx's
+          to do.
+        parameters:
+          node:
+            type: ast.Name
+          expected:
+            type: SigType
+        returns:
+          type: astx.DataType
+        """
+        return astx.Variable(name=node.id, loc=location(self.extracted, node))
+
+    @dispatch
+    def expression(self, node: ast.BinOp, expected: SigType) -> astx.DataType:
+        """
+        title: Lower an arithmetic binary operation.
+        summary: >-
+          Both operands are lowered at the expected type, so a literal in
+          either position takes the width of its context rather than Python's.
+          The result type is IRx's to compute from the operands.
+        parameters:
+          node:
+            type: ast.BinOp
+          expected:
+            type: SigType
+        returns:
+          type: astx.DataType
+        raises:
+          LoweringError: If the operator has no astx equivalent.
+        """
+        op_code = _BINARY_OPS.get(type(node.op))
+        if op_code is None:
+            name = type(node.op).__name__
+            raise self.reject(
+                node,
+                f"cannot lower the {name} operator: astx has no binary"
+                " operator for it",
+            )
+        return astx.BinaryOp(
+            op_code,
+            self.expression(node.left, expected),
+            self.expression(node.right, expected),
+            loc=location(self.extracted, node),
+        )
+
+    @dispatch
+    def expression(
+        self, node: ast.UnaryOp, expected: SigType
+    ) -> astx.DataType:
+        """
+        title: Lower a unary operation.
+        summary: >-
+          A unary plus is the identity and lowers to its operand alone. A
+          negated literal is folded into one negative literal, which is the
+          only form a negative constant takes in Python and the only negation
+          that can be lowered at all: IRx implements no unary minus, so
+          negating anything else is refused rather than emitted as a node
+          codegen would later reject.
+        parameters:
+          node:
+            type: ast.UnaryOp
+          expected:
+            type: SigType
+        returns:
+          type: astx.DataType
+        raises:
+          LoweringError: If the operator has no astx equivalent.
+        """
+        if isinstance(node.op, ast.UAdd):
+            return self.expression(node.operand, expected)
+        if isinstance(node.op, ast.USub):
+            operand = node.operand
+            if isinstance(operand, ast.Constant) and isinstance(
+                operand.value, (int, float)
+            ):
+                return self.literal(node, -operand.value, expected)
+            raise self.reject(
+                node,
+                "cannot lower a negation of anything but a literal: IRx"
+                " implements no unary minus",
+            )
+        op_code = _UNARY_OPS.get(type(node.op))
+        if op_code is None:
+            name = type(node.op).__name__
+            raise self.reject(
+                node,
+                f"cannot lower the {name} operator: astx has no unary"
+                " operator for it",
+            )
+        return astx.UnaryOp(
+            op_code,
+            self.expression(node.operand, expected),
+            loc=location(self.extracted, node),
+        )
 
     def _literal_value(
-        self, node: ast.Constant, expected: SigType, target: _Scalar
+        self,
+        node: ast.expr,
+        value: object,
+        expected: SigType,
+        target: _Scalar,
     ) -> bool | int | float:
         """
         title: Check a literal against its expected type and convert it.
@@ -408,14 +565,15 @@ class Lowerer:
           that order True would satisfy an integer context. An integer in a
           float context is converted, which is the widening Python itself
           performs; the reverse is not, because a float has no integer value to
-          preserve. Note that a negative literal never arrives here as one:
-          Python parses it as a unary minus applied to a positive constant, so
-          when that operator is lowered the range check has to be applied to
-          the negated value, or the exact minimum of a signed type would be
-          refused for exceeding its own maximum.
+          preserve. The value is passed in rather than read off the node so a
+          negated constant is checked as the negative number it is, which is
+          what admits the exact minimum of a signed type: its magnitude alone
+          is one larger than that type's maximum.
         parameters:
           node:
-            type: ast.Constant
+            type: ast.expr
+          value:
+            type: object
           expected:
             type: SigType
           target:
@@ -425,7 +583,6 @@ class Lowerer:
         raises:
           LoweringError: If the literal's kind or value does not fit.
         """
-        value = node.value
         if isinstance(value, bool):
             if target.kind != "bool":
                 raise self.reject(
@@ -452,7 +609,7 @@ class Lowerer:
 
     def _in_range(
         self,
-        node: ast.Constant,
+        node: ast.expr,
         value: int,
         expected: SigType,
         target: _Scalar,
@@ -465,7 +622,7 @@ class Lowerer:
           still be labelled Int64 and misstate its own value.
         parameters:
           node:
-            type: ast.Constant
+            type: ast.expr
           value:
             type: int
           expected:
@@ -487,7 +644,7 @@ class Lowerer:
 
     def _as_float(
         self,
-        node: ast.Constant,
+        node: ast.expr,
         value: int | float,
         expected: SigType,
         target: _Scalar,
@@ -500,7 +657,7 @@ class Lowerer:
           steps are checked rather than left to produce an infinity.
         parameters:
           node:
-            type: ast.Constant
+            type: ast.expr
           value:
             type: int | float
           expected:

--- a/packages/arxjit/tests/test_lowering.py
+++ b/packages/arxjit/tests/test_lowering.py
@@ -22,6 +22,7 @@ from arxjit.lowering import (
 from arxjit.source import ExtractedSource, extract_source
 from arxjit.types import Signature, SigType, bool_, f32, f64, i32, i64
 from astx.base import NO_SOURCE_LOCATION
+from astx.binary_op import _BINARY_OP_TYPES
 from irx.analysis.api import analyze
 from irx.analysis.registry import MAIN_FUNCTION_NAME
 
@@ -395,21 +396,193 @@ def test_a_float_overflow_reported_by_exception_is_rejected(
     assert "out of range" in str(excinfo.value)
 
 
-def test_a_negative_literal_is_not_a_literal_yet() -> None:
+def test_a_negated_literal_folds_into_one_negative_literal() -> None:
     """
-    title: A negative number reaches this stage as a unary minus.
+    title: A negative number lowers as a literal, not as an operator.
     summary: >-
-      Pinned because it is a trap for the operator lowering that follows.
-      Python parses -1 as USub applied to the constant 1, so no negative value
-      ever reaches the constant overload, and the range check only ever sees
-      the magnitude. Applying that check before the negation would refuse the
-      exact minimum of a signed type, which is one larger in magnitude than its
-      maximum: -2147483648 is a valid i32 while 2147483648 is not.
+      Python parses -1 as USub applied to the constant 1, so a negative value
+      never reaches the constant overload on its own. Folding is what makes it
+      lowerable at all, since IRx implements no unary minus, and it is also
+      what admits the exact minimum of a signed type: -2147483648 is a valid
+      i32 while its magnitude, 2147483648, is not. This is the test the
+      previous PR left failing for this one to flip.
     """
-    source = f"def sample():\n    return -{2**31}\n"
+    definition = _from_source(f"def sample():\n    return -{2**31}\n", i32())
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.LiteralInt32)
+    assert returned.value.value == -(2**31)
+
+
+def test_a_negated_literal_below_the_minimum_is_still_rejected() -> None:
+    """
+    title: Folding widens what is accepted by exactly one value, not more.
+    summary: >-
+      The boundary partner of the test above: the fold must admit the minimum
+      without also admitting everything past it.
+    """
     with pytest.raises(LoweringError) as excinfo:
-        _from_source(source, i32())
-    assert "cannot lower a UnaryOp expression" in str(excinfo.value)
+        _from_source(f"def sample():\n    return -{2**31 + 1}\n", i32())
+    assert "out of range" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("operator", "op_code"),
+    [("+", "+"), ("-", "-"), ("*", "*"), ("/", "/"), ("%", "%")],
+)
+def test_each_arithmetic_operator_lowers_and_analyses(
+    operator: str, op_code: str
+) -> None:
+    """
+    title: Every supported binary operator survives IRx analysis.
+    summary: >-
+      Run through analysis rather than only inspected, because an op_code astx
+      does not know specializes to no node and only fails later, in codegen.
+    parameters:
+      operator:
+        type: str
+      op_code:
+        type: str
+    """
+    source = f"def sample(a, b):\n    return a {operator} b\n"
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    module = lower(
+        ExtractedSource(filename="<test>", source=source, lineno=1, node=node),
+        f64(f64, f64),
+    )
+    definition = module.block[0]
+    assert isinstance(definition, astx.FunctionDef)
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.BinaryOp)
+    assert returned.value.op_code == op_code
+    analyze(module)
+
+
+def test_a_parameter_read_lowers_to_a_variable() -> None:
+    """
+    title: A name reads the parameter of that name.
+    summary: >-
+      The reference carries no type: the prototype already declares it, and
+      reconciling a variable with its context is IRx's to do, unlike a literal
+      whose width this stage chooses.
+    """
+    definition = _from_source("def sample(a):\n    return a\n", i64(i64))
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.Variable)
+    assert returned.value.name == "a"
+
+
+def test_operand_literals_take_the_expected_width() -> None:
+    """
+    title: A literal inside an expression is built at the declared width.
+    summary: >-
+      The expected type is propagated into both operands, so the same rule that
+      governs a returned literal governs one buried in an expression; an Int64
+      literal here would fail analysis in an i32 function.
+    """
+    definition = _from_source("def sample(a):\n    return a + 1\n", i32(i32))
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.BinaryOp)
+    assert isinstance(returned.value.rhs, astx.LiteralInt32)
+
+
+def test_a_unary_plus_lowers_to_its_operand() -> None:
+    """
+    title: A unary plus contributes no node.
+    summary: >-
+      It is the identity, and IRx has no operator for it, so the operand is
+      lowered alone rather than wrapped in something codegen would reject.
+    """
+    definition = _from_source("def sample(a):\n    return +a\n", i64(i64))
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.Variable)
+
+
+def test_a_logical_not_lowers_to_the_astx_operator() -> None:
+    """
+    title: not lowers to the one unary operator IRx implements.
+    """
+    source = "def sample(a):\n    return not a\n"
+    node = ast.parse(source).body[0]
+    assert isinstance(node, ast.FunctionDef)
+    module = lower(
+        ExtractedSource(filename="<test>", source=source, lineno=1, node=node),
+        bool_(bool_),
+    )
+    definition = module.block[0]
+    assert isinstance(definition, astx.FunctionDef)
+    (returned,) = definition.body.nodes
+    assert isinstance(returned, astx.FunctionReturn)
+    assert isinstance(returned.value, astx.UnaryOp)
+    assert returned.value.op_code == "!"
+    analyze(module)
+
+
+@pytest.mark.parametrize(
+    ("operator", "name"), [("//", "FloorDiv"), ("**", "Pow")]
+)
+def test_an_operator_astx_lacks_is_rejected(operator: str, name: str) -> None:
+    """
+    title: An operator with no astx entry is refused, not emitted.
+    summary: >-
+      Validation admits both of these, but astx maps neither to a specialized
+      node, so each would reach codegen as "not implemented yet". Refusing here
+      keeps the disagreement between the subset and the backend visible as a
+      diagnostic rather than as a failure much later.
+    parameters:
+      operator:
+        type: str
+      name:
+        type: str
+    """
+    source = f"def sample(a, b):\n    return a {operator} b\n"
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source(source, i64(i64, i64))
+    assert f"cannot lower the {name} operator" in str(excinfo.value)
+
+
+def test_negating_a_variable_is_rejected() -> None:
+    """
+    title: Only a literal can be negated.
+    summary: >-
+      IRx implements ++, -- and ! and no unary minus, so a negated variable has
+      no operator to lower onto. Emitting one anyway would produce a module
+      that analyses cleanly and then fails in codegen.
+    """
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source("def sample(a):\n    return -a\n", i64(i64))
+    assert "IRx implements no unary minus" in str(excinfo.value)
+
+
+def test_a_unary_operator_astx_lacks_is_rejected() -> None:
+    """
+    title: A unary operator with no astx entry is refused.
+    summary: >-
+      Validation rejects ~ before lowering runs, so this is reached only
+      through the public entry point; IRx implements no bitwise inversion, so
+      it must not be emitted.
+    """
+    with pytest.raises(LoweringError) as excinfo:
+        _from_source("def sample(a):\n    return ~a\n", i64(i64))
+    assert "cannot lower the Invert operator" in str(excinfo.value)
+
+
+def test_the_operator_tables_agree_with_astx() -> None:
+    """
+    title: Every operator this stage emits is one astx specializes.
+    summary: >-
+      astx falls back to a plain BinaryOp for an unknown op_code rather than
+      raising, so an operator added here without an entry there would lower
+      quietly and only fail in codegen. Read from astx directly so the check
+      cannot go stale.
+    """
+    for op_code in lowering._BINARY_OPS.values():
+        assert op_code in _BINARY_OP_TYPES
 
 
 def test_docstring_and_pass_lower_to_nothing() -> None:
@@ -506,11 +679,15 @@ def test_an_unlowerable_statement_fails_closed() -> None:
 def test_an_unlowerable_expression_fails_closed() -> None:
     """
     title: An expression with no overload is reported, not skipped.
+    summary: >-
+      Validation admits comparisons, so reaching one here means the subset and
+      the lowerer disagree. They lower with the conditionals that give them a
+      purpose, not before.
     """
-    source = "def sample(x):\n    return x\n"
+    source = "def sample(x):\n    return x < 1\n"
     with pytest.raises(LoweringError) as excinfo:
-        _from_source(source, i64(i64))
-    assert "cannot lower a Name expression" in str(excinfo.value)
+        _from_source(source, bool_(i64))
+    assert "cannot lower a Compare expression" in str(excinfo.value)
 
 
 def test_a_standalone_expression_statement_is_rejected() -> None:


### PR DESCRIPTION
Second stage of the Sprint 3 lowering work, after #107 covered the function
shell. Adds parameter reads, arithmetic, and unary operators, so the wiki's
own example lowers end to end:

```python
def add(a, b):
    return a + b
```

Operand types propagate: both sides of an operator are lowered at the expected
type, so a literal buried in an expression takes the width of its context
exactly as a returned one does. A variable read carries no type of its own,
because the prototype already declares it and reconciling it with its context
is IRx's to do. That is the deliberate difference from a literal, whose width
this stage chooses.

### Two disagreements between validation and the backend

I read the operator vocabulary off astx and IRx rather than off the Python
grammar, which turned up two constructs the subset admits but the backend
cannot express:

1. **`//` and `**` have no astx operator.** astx maps op_codes to specialized
   nodes through `_BINARY_OP_TYPES`, which has no entry for `ast.FloorDiv` or
   `ast.Pow`. An unmapped op_code does not raise: it stays a plain `BinaryOp`
   and reaches codegen as `Binary op ** not implemented yet`. Validation
   accepts both, so they are rejected here rather than lowered into a module
   that cannot compile. A test reads astx's table directly so ours cannot
   drift from it.
2. **IRx has no unary minus.** `unary_ops.py` implements `++`, `--` and `!`,
   and raises for anything else. A unary plus needs no node, being the
   identity, and a negated literal is folded into one negative literal, which
   is the only form a negative constant takes in Python. Negating anything
   else is rejected.

**Both are worth a decision beyond this PR:** either validation should stop
accepting these, or astx/IRx should gain the operators. Rejecting at lowering
keeps them visible as diagnostics meanwhile, but the subset and the backend
disagreeing is not a good resting state. Happy to open an issue for whichever
direction you prefer.

### The negative-literal trap from #107

Folding also closes the trap #107 flagged and deliberately left a failing test
for: a range check applied to the magnitude alone would refuse `-2147483648`,
whose magnitude is one larger than the i32 maximum. That test is flipped here,
with a boundary partner confirming the fold widens what is accepted by exactly
that one value and no further.

### Scope

Comparisons stay unlowered. Validation accepts them, but they only mean
something alongside the conditionals they belong to, so they lower with those
in the next PR. `@jit` still does not call this stage; that wiring is the last
PR of the sprint.

251 tests, arxjit coverage 100% line and branch. Every operator verified
through `irx.analysis.api.analyze`, and lowering verified on CPython 3.10,
3.11 and 3.14.
